### PR TITLE
Add a Vagrantfile for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+inventory.vagrant
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,11 +58,14 @@ Vagrant.configure(2) do |config|
     v.vmx["memsize"] = MEMORY
   end
 
-  config.vm.provision "ansible" do |ansible|
-    ansible.raw_arguments = "--private-key=~/.vagrant.d/insecure_private_key"
-    ansible.verbose = "vv"
-    ansible.playbook = "site.yml"
-    ansible.extra_vars = "globals.yml"
-    ansible.inventory_path = INVENTORY_FILE
+  config.vm.define HOSTS.last[:name] do |host|
+	host.vm.provision :ansible do |ansible|
+ 	  ansible.raw_arguments = "--private-key=~/.vagrant.d/insecure_private_key"
+	  ansible.verbose = "vv"
+	  ansible.playbook = "site.yml"
+	  ansible.extra_vars = "globals.yml"
+	  ansible.inventory_path = INVENTORY_FILE
+	  ansible.limit = "all"
+    end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,66 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+INVENTORY_FILE = "inventory.vagrant"
+MEMORY = 384
+HOSTS = [
+  { name: 'tsuru-i1', ip: '172.18.10.11',
+    roles: %w{api mongodb} },
+  { name: 'tsuru-i2', ip: '172.18.10.12',
+    roles: %w{gandalf redis-master} },
+  { name: 'tsuru-i3', ip: '172.18.10.13',
+    roles: %w{hipache nodes} },
+  { name: 'tsuru-i4', ip: '172.18.10.14',
+    roles: %w{nodes} },
+]
+
+def generate_inventory(hosts, file)
+  roles = {}
+
+  File.open(file, "w") do |f|
+    hosts.each do |host|
+      host_string = "#{host[:name]} \
+internal_ip=#{host[:ip]} \
+external_ip=#{host[:ip]} \
+ansible_ssh_host=#{host[:ip]}\n"
+
+      f.write(host_string)
+      host[:roles].each do |role|
+        roles[role] ||= []
+        roles[role] << host_string
+      end
+    end
+
+    roles.each do |role, hosts|
+      f.write("\n[#{role}]\n")
+      f.write(hosts.join)
+    end
+  end
+end
+
+generate_inventory(HOSTS, INVENTORY_FILE) if %w{up provision}.include?(ARGV[0])
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "puppetlabs/ubuntu-14.04-64-nocm"
+
+  HOSTS.each do |host|
+    config.vm.define host[:name] do |c|
+      c.vm.hostname = host[:name]
+      c.vm.network :private_network, ip: host[:ip]
+    end
+  end
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = MEMORY
+  end
+
+  config.vm.provider :vmware_fusion do |v|
+    v.vmx["memsize"] = MEMORY
+  end
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "site.yml"
+    ansible.extra_vars = "globals.yml"
+    ansible.inventory_path = INVENTORY_FILE
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,6 +59,8 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "ansible" do |ansible|
+    ansible.raw_arguments = "--private-key=~/.vagrant.d/insecure_private_key"
+    ansible.verbose = "vv"
     ansible.playbook = "site.yml"
     ansible.extra_vars = "globals.yml"
     ansible.inventory_path = INVENTORY_FILE

--- a/roles/docker_server/tasks/main.yml
+++ b/roles/docker_server/tasks/main.yml
@@ -15,3 +15,6 @@
   lineinfile: dest=/etc/default/docker line='export DOCKER_OPTS="-H 0.0.0.0:{{ docker_port }} --insecure-registry={{docker_registry_host}}:{{docker_registry_port}}"'
   notify:
     - restart docker
+
+- name: Start docker
+  service: name=docker state=started

--- a/roles/gandalf/tasks/main.yml
+++ b/roles/gandalf/tasks/main.yml
@@ -33,8 +33,14 @@
     - restart gandalf
     - restart archive-server
 
+- name: Start gandalf
+  service: name=gandalf-server state=started
+
 - name: Update archive server conf.
   template: dest=/etc/default/archive-server src=archive-server.j2
   notify:
     - restart gandalf
     - restart archive-server
+
+- name: Start archive-server
+  service: name=archive-server state=started

--- a/roles/hipache/tasks/main.yml
+++ b/roles/hipache/tasks/main.yml
@@ -25,3 +25,6 @@
   template: src=hipache.conf.j2 dest=/etc/hipache.conf
   notify:
     - restart hipache
+
+- name: Start hipache
+  service: name=hipache state=started

--- a/roles/tsuru_api/tasks/main.yml
+++ b/roles/tsuru_api/tasks/main.yml
@@ -28,6 +28,10 @@
     tsuru-admin target-remove local;
     tsuru-admin target-add local http://127.0.0.1:{{api_port}} -s
 
+# Wait until the tsuru-server-api is up
+- name: Wait for tsuru-server to be up
+  wait_for: port={{api_port}} timeout=60
+
 # TODO: handle the case where the user already exists
 - name: Add admin user.
   shell: >

--- a/roles/tsuru_api/tasks/main.yml
+++ b/roles/tsuru_api/tasks/main.yml
@@ -18,6 +18,9 @@
   notify:
     - restart tsuru_api
 
+- name: Start tsuru_api
+  service: name=tsuru-server-api state=started
+
 # Remove target first otherwise add will fail.
 # Note that remove target does not fail if target exists
 - name: Configure tsuru-admin command.

--- a/roles/tsuru_api/tasks/main.yml
+++ b/roles/tsuru_api/tasks/main.yml
@@ -39,8 +39,3 @@
   shell: >
     token=$(curl -sS -XPOST -d"{\"password\":\"{{admin_password}}\"}" "http://127.0.0.1:{{api_port}}/users/{{admin_user}}/tokens" | jq -r .token);
     echo "${token}" > ~/.tsuru_token
-
-- name: Install python platform
-  command: tsuru-admin platform-add python --dockerfile https://raw.githubusercontent.com/tsuru/basebuilder/master/python/Dockerfile
-  register: command_result
-  failed_when: "command_result.stderr and 'Duplicate platform' not in command_result.stderr"

--- a/roles/tsuru_api/tasks/main.yml
+++ b/roles/tsuru_api/tasks/main.yml
@@ -28,7 +28,6 @@
     tsuru-admin target-remove local;
     tsuru-admin target-add local http://127.0.0.1:{{api_port}} -s
 
-# Wait until the tsuru-server-api is up
 - name: Wait for tsuru-server to be up
   wait_for: port={{api_port}} timeout=60
 


### PR DESCRIPTION
Which mimics the four machines currently in `inventory`. This will be useful
for offline testing or working in parallel to other people.

I found that I had to write the inventory file dynamically because I
couldn't assign the `internal_ip` and `external_ip` variables when using
Vagrant's `groups` support. I think I've also mixed up the terminology for
"hosts" and "roles".

I'm using the PuppetLabs Ubuntu 14.04 box because it's pretty minimal and
supports both VirtualBox and VMware (which the official Ubuntu box doesn't).

There are some ordering issues to work out. It takes several runs on all
machines for them to complete successfully. This might account for the
non-numerical order of the original `inventory` file. We might be able to
help this by breaking each component out to it's own machine and ensuring
that databases happen first.
