### PR TITLE
Ensure that all services are started

### DIFF
--- a/roles/docker_server/tasks/main.yml
+++ b/roles/docker_server/tasks/main.yml
@@ -15,3 +15,6 @@
   lineinfile: dest=/etc/default/docker line='export DOCKER_OPTS="-H 0.0.0.0:{{ docker_port }} --insecure-registry={{docker_registry_host}}:{{docker_registry_port}}"'
   notify:
     - restart docker
+
+- name: Start docker
+  service: name=docker state=started

--- a/roles/gandalf/tasks/main.yml
+++ b/roles/gandalf/tasks/main.yml
@@ -33,8 +33,14 @@
     - restart gandalf
     - restart archive-server
 
+- name: Start gandalf
+  service: name=gandalf-server state=started
+
 - name: Update archive server conf.
   template: dest=/etc/default/archive-server src=archive-server.j2
   notify:
     - restart gandalf
     - restart archive-server
+
+- name: Start archive-server
+  service: name=archive-server state=started

--- a/roles/hipache/tasks/main.yml
+++ b/roles/hipache/tasks/main.yml
@@ -25,3 +25,6 @@
   template: src=hipache.conf.j2 dest=/etc/hipache.conf
   notify:
     - restart hipache
+
+- name: Start hipache
+  service: name=hipache state=started

--- a/roles/tsuru_api/tasks/main.yml
+++ b/roles/tsuru_api/tasks/main.yml
@@ -18,6 +18,9 @@
   notify:
     - restart tsuru_api
 
+- name: Start tsuru_api
+  service: name=tsuru-server-api state=started
+
 # Remove target first otherwise add will fail.
 # Note that remove target does not fail if target exists
 - name: Configure tsuru-admin command.


### PR DESCRIPTION
By managing them with tasks, rather than only [re]starting them with a handler
when a config file changes. This fixes the following error when bringing up an
API machine:

```
TASK: [tsuru_api | Copy configuration file.] **********************************
changed: [tsuru-i1]TASK: [tsuru_api | Copy tsuru-server file.] ***********************************
changed: [tsuru-i1]

TASK: [tsuru_api | Configure tsuru-admin command.] ****************************
changed: [tsuru-i1]

TASK: [tsuru_api | Add admin user.] *******************************************
failed: [tsuru-i1] => {"changed": true, "cmd": "mongo tsuru --eval 'db.teams.update({_id: \"admin\"}, {_id: \"admin\"}, {upsert: true})'; mongo tsuru --eval \"db.teams.update({_id: 'admin'}, {\\$addToSet: {users: 'administrator@gds.tsuru.gov'}})\"; curl -sS -XPOST -d\"{\\\"email\\\":\\\"administrator@gds.tsuru.gov\\\",\\\"password\\\":\\\"admin123\\\"}\" \"http://127.0.0.1:8080/users\"", "delta": "0:00:00.245872", "end": "2015-03-31 07:01:55.743474", "rc": 7, "start": "2015-03-31 07:01:55.497602", "warnings": []}
stderr: curl: (7) Failed to connect to 127.0.0.1 port 8080: Connection refused
stdout: MongoDB shell version: 2.6.9
connecting to: tsuru
WriteResult({ "nMatched" : 0, "nUpserted" : 1, "nModified" : 0, "_id" : "admin" })
MongoDB shell version: 2.6.9
connecting to: tsuru
WriteResult({ "nMatched" : 1, "nUpserted" : 0, "nModified" : 1 })
```

Also includes some whitespace changes because some of the files didn't
contain EOF newlines.

Tested in Vagrant /cc @mikkoc 
