### PR TITLE
Remove `platform-add python` task

### DIFF
--- a/roles/tsuru_api/tasks/main.yml
+++ b/roles/tsuru_api/tasks/main.yml
@@ -39,8 +39,3 @@
   shell: >
     token=$(curl -sS -XPOST -d"{\"password\":\"{{admin_password}}\"}" "http://127.0.0.1:{{api_port}}/users/{{admin_user}}/tokens" | jq -r .token);
     echo "${token}" > ~/.tsuru_token
-
-- name: Install python platform
-  command: tsuru-admin platform-add python --dockerfile https://raw.githubusercontent.com/tsuru/basebuilder/master/python/Dockerfile
-  register: command_result
-  failed_when: "command_result.stderr and 'Duplicate platform' not in command_result.stderr"


### PR DESCRIPTION
Nassim and I were unsure about adding this in the first place. I've now come
the conclusion that it's not terribly useful because it:
- depends on a Docker node which currently comes after the API node
- takes a long time and doesn't give any feedback about its progress
- pulls directly from GitHub master so may not be reproducible
- isn't used because we don't install the tsuru/tsuru-dashboard app

So I think we should remove it and do this step afterwards, along with other
platforms, perhaps still from Ansible, but not during the initial install.
