### PR TITLE
Wait for API server to be up

### DIFF
--- a/roles/tsuru_api/tasks/main.yml
+++ b/roles/tsuru_api/tasks/main.yml
@@ -28,6 +28,10 @@
     tsuru-admin target-remove local;
     tsuru-admin target-add local http://127.0.0.1:{{api_port}} -s
 
+# Wait until the tsuru-server-api is up
+- name: Wait for tsuru-server to be up
+  wait_for: port={{api_port}} timeout=60
+
 # TODO: handle the case where the user already exists
 - name: Add admin user.
   shell: >

--- a/roles/tsuru_api/tasks/main.yml
+++ b/roles/tsuru_api/tasks/main.yml
@@ -28,7 +28,6 @@
     tsuru-admin target-remove local;
     tsuru-admin target-add local http://127.0.0.1:{{api_port}} -s
 
-# Wait until the tsuru-server-api is up
 - name: Wait for tsuru-server to be up
   wait_for: port={{api_port}} timeout=60
 


### PR DESCRIPTION
If we don't wait, the next task (add admin user) might fail with this error:

TASK: [tsuru_api | Add admin user.] *******************************************
<172.18.10.11> REMOTE_MODULE command mongo tsuru --eval 'db.teams.update({_id: "admin"}, {_id: "admin"}, {upsert: true})'; mongo tsuru --eval "db.teams.update({_id: 'admin'}, {\$addToSet: {users:  curl -sS -XPOST -d"{\"email\":*******_@gds.tsuru.gov\",\"password\":\"**_******_\"}" "http://127.0.0.1:8080/users" #USE_SHELL
failed: [tsuru-i1] => {"changed": true, "cmd": "mongo tsuru --eval 'db.teams.update({_id: \"admin\"}, {_id: \"admin\"}, {upsert: true})'; mongo tsuru --eval \"db.teams.update({_id: 'admin'}, {\$addToSet: {users: 'administrator@gds.tsuru.gov'}})\"; curl -sS -XPOST -d\"{\\"email\\":\\"**_****_@gds.tsuru.gov\\",\\"password\\":\\"**_*****\\"}\" \"http://127.0.0.1:8080/users\"", "delta": "0:00:00.488796", "end": "2015-04-02 04:34:11.876517", "rc": 7, "start": "2015-04-02
04:34:11.387721", "warnings": []}
stderr: curl: (7) Failed to connect to 127.0.0.1 port 8080: Connection refused

FATAL: all hosts have already failed -- aborting
