### PR TITLE
Configure private instances

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ def generate_inventory(hosts, file)
     hosts.each do |host|
       host_string = "#{host[:name]} \
 internal_ip=#{host[:ip]} \
-external_ip=#{host[:ip]} \
+external_ip=#{host[:ip]}.xip.io \
 ansible_ssh_host=#{host[:ip]}\n"
 
       f.write(host_string)

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -170,7 +170,7 @@ fact_caching = memory
 # ssh arguments to use
 # Leaving off ControlPersist will result in poor performance, so use
 # paramiko on older platforms rather than removing it
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s 
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -F ssh.config
 
 # The path to use for the ControlPath sockets. This defaults to
 # "%(directory)s/ansible-ssh-%%h-%%p-%%r", however on some systems with

--- a/globals.yml
+++ b/globals.yml
@@ -3,15 +3,19 @@
 redis_host: "{{ hostvars[groups['redis-master'][0]].internal_ip }}"
 redis_port: 6379
 
-tsuru_api_host: "{{ hostvars[groups['api'][0]].external_ip }}"
+tsuru_api_internal_lb: "{{ hostvars[groups['api'][0]].internal_ip }}"
 
-docker_registry_host: "{{ hostvars[groups['hipache'][0]].internal_ip }}"
+docker_registry_host: "{{ hostvars[groups['docker-registry'][0]].internal_ip }}"
 
 # need to be 5000 when no nginx is used.
 docker_registry_port: 5000
 docker_port: 4243
 
-gandalf_host: "{{ hostvars[groups['gandalf'][0]].external_ip }}"
+hipache_host_external_lb: "{{ hostvars[groups['hipache'][0]].external_ip }}"
+hipache_host_internal_lb: "{{ hostvars[groups['hipache'][0]].internal_ip }}"
+
+gandalf_host_internal: "{{ hostvars[groups['gandalf'][0]].internal_ip }}"
+gandalf_host_external: "{{ hostvars[groups['gandalf'][0]].external_ip }}"
 gandalf_port: 8080
 
 mongodb_host: "{{ hostvars[groups['mongodb'][0]].internal_ip }}"

--- a/inventory-aws
+++ b/inventory-aws
@@ -1,25 +1,28 @@
-52.17.23.132    internal_ip=10.128.1.77    external_ip=52.17.23.132    name=tsuru-api
-52.17.154.17    internal_ip=10.128.1.166    external_ip=52.17.154.17    name=tsuru-gandalf
-52.17.55.99     internal_ip=10.128.1.224     external_ip=52.17.55.99     name=tsuru-docker
-52.17.30.246    internal_ip=10.128.3.191    external_ip=52.17.30.246    name=tsuru-router
-52.16.80.142    internal_ip=10.128.1.157    external_ip=52.16.80.142    name=tsuru-router
+10.128.1.16     internal_ip=10.128.1.16    external_ip=api.tsuru.paas.alphagov.co.uk    name=tsuru-api
+10.128.0.192    internal_ip=10.128.0.192    external_ip=gandalf.tsuru.paas.alphagov.co.uk    name=tsuru-gandalf
+10.128.1.101     internal_ip=10.128.1.101     name=tsuru-docker
+10.128.1.127    internal_ip=10.128.1.127    external_ip=hipache.tsuru.paas.alphagov.co.uk    name=tsuru-router
+10.128.3.65     internal_ip=10.128.3.65	external_ip=hipache.tsuru.paas.alphagov.co.uk	name=tsuru-router
 
 [api]
-52.17.23.132	internal_ip=10.128.1.77	external_ip=52.17.23.132	name=tsuru-api
+10.128.1.16     internal_ip=internal.api.tsuru.paas.alphagov.co.uk	name=tsuru-api
 
 [mongodb]
-52.17.23.132	internal_ip=10.128.1.77	external_ip=52.17.23.132	name=tsuru-api
+10.128.1.16     internal_ip=10.128.1.16     name=tsuru-api
 
 [gandalf]
-52.17.154.17	internal_ip=10.128.1.166	external_ip=52.17.154.17	name=tsuru-gandalf
+10.128.0.192	internal_ip=10.128.0.192     external_ip=gandalf.tsuru.paas.alphagov.co.uk	name=tsuru-gandalf
 
 [redis-master]
-52.17.23.132	internal_ip=10.128.1.77	external_ip=52.17.23.132	name=tsuru-api
+10.128.1.16	    internal_ip=10.128.1.16     name=tsuru-api
+
+[docker-registry]
+10.128.1.101    internal_ip=10.128.1.101 	name=tsuru-docker
 
 [hipache]
-52.17.30.246	internal_ip=10.128.3.191	external_ip=hipache.tsuru.paas.alphagov.co.uk	name=tsuru-router
-52.16.80.142	internal_ip=10.128.1.157	external_ip=hipache.tsuru.paas.alphagov.co.uk	name=tsuru-router
+10.128.1.127	internal_ip=10.128.1.127	external_ip=hipache.tsuru.paas.alphagov.co.uk	name=tsuru-router
+10.128.3.65     internal_ip=10.128.3.65     external_ip=hipache.tsuru.paas.alphagov.co.uk	name=tsuru-router
 
 [nodes]
-52.17.55.99	    internal_ip=10.128.1.224	    external_ip=52.17.55.99 	name=tsuru-docker
+10.128.1.101    internal_ip=10.128.1.101 	name=tsuru-docker
 

--- a/inventory-aws
+++ b/inventory-aws
@@ -1,0 +1,25 @@
+52.17.23.132    internal_ip=10.128.1.77    external_ip=52.17.23.132    name=tsuru-api
+52.17.154.17    internal_ip=10.128.1.166    external_ip=52.17.154.17    name=tsuru-gandalf
+52.17.55.99     internal_ip=10.128.1.224     external_ip=52.17.55.99     name=tsuru-docker
+52.17.30.246    internal_ip=10.128.3.191    external_ip=52.17.30.246    name=tsuru-router
+52.16.80.142    internal_ip=10.128.1.157    external_ip=52.16.80.142    name=tsuru-router
+
+[api]
+52.17.23.132	internal_ip=10.128.1.77	external_ip=52.17.23.132	name=tsuru-api
+
+[mongodb]
+52.17.23.132	internal_ip=10.128.1.77	external_ip=52.17.23.132	name=tsuru-api
+
+[gandalf]
+52.17.154.17	internal_ip=10.128.1.166	external_ip=52.17.154.17	name=tsuru-gandalf
+
+[redis-master]
+52.17.23.132	internal_ip=10.128.1.77	external_ip=52.17.23.132	name=tsuru-api
+
+[hipache]
+52.17.30.246	internal_ip=10.128.3.191	external_ip=hipache.tsuru.paas.alphagov.co.uk	name=tsuru-router
+52.16.80.142	internal_ip=10.128.1.157	external_ip=hipache.tsuru.paas.alphagov.co.uk	name=tsuru-router
+
+[nodes]
+52.17.55.99	    internal_ip=10.128.1.224	    external_ip=52.17.55.99 	name=tsuru-docker
+

--- a/roles/gandalf/tasks/main.yml
+++ b/roles/gandalf/tasks/main.yml
@@ -16,7 +16,7 @@
     chown -R git:git /home/git/bare-template;
 
 - name: Add archive server to bash profile.
-  lineinfile: 'create=yes dest=/home/git/.bash_profile line="export ARCHIVE_SERVER_READ=http://{{external_ip}}:3232 ARCHIVE_SERVER_WRITE=http://127.0.0.1:3131"'
+  lineinfile: 'create=yes dest=/home/git/.bash_profile line="export ARCHIVE_SERVER_READ=http://{{gandalf_host_internal}}:3232 ARCHIVE_SERVER_WRITE=http://127.0.0.1:3131"'
   notify:
     - restart gandalf
     - restart archive-server

--- a/roles/gandalf/tasks/main.yml
+++ b/roles/gandalf/tasks/main.yml
@@ -22,7 +22,7 @@
     - restart archive-server
 
 - name: Add api endpoint to bash_profile
-  lineinfile: 'create=yes dest=/home/git/.bash_profile line="export TSURU_HOST=http://{{tsuru_api_host}}:8080"'
+  lineinfile: 'create=yes dest=/home/git/.bash_profile line="export TSURU_HOST=http://{{tsuru_api_internal_lb}}:8080"'
   notify:
     - restart gandalf
     - restart archive-server

--- a/roles/tsuru_api/templates/tsuru.conf.j2
+++ b/roles/tsuru_api/templates/tsuru.conf.j2
@@ -155,7 +155,7 @@ auth:
 #
 provisioner: docker
 hipache:
-   domain: {{hipache_host}}.xip.io
+   domain: {{hipache_host}}
    redis-server: {{redis_host}}:{{redis_port}}
 docker:
    registry: {{ docker_registry_host }}:{{ docker_registry_port }}

--- a/roles/tsuru_api/templates/tsuru.conf.j2
+++ b/roles/tsuru_api/templates/tsuru.conf.j2
@@ -156,7 +156,7 @@ auth:
 #
 provisioner: docker
 hipache:
-   domain: {{hipache_host}}
+   domain: {{hipache_host_external_lb}}
    redis-server: {{redis_host}}:{{redis_port}}
 docker:
    registry: {{ docker_registry_host }}:{{ docker_registry_port }}

--- a/roles/tsuru_api/templates/tsuru.conf.j2
+++ b/roles/tsuru_api/templates/tsuru.conf.j2
@@ -1,7 +1,7 @@
 listen: "0.0.0.0:{{api_port}}"
 admin-listen: "0.0.0.0:8081"
 
-host: http://{{external_ip}}:{{api_port}}
+host: http://{{tsuru_api_internal_lb}}:{{api_port}}
 
 # Uncomment the following lines to enable HTTPS on Tsuru. You will need the
 # paths to the certificate and key files.
@@ -35,7 +35,8 @@ database:
 #              units. You may use the private IP of the Gandalf host.
 git:
   unit-repo: /home/application/current
-  api-server: http://{{gandalf_host}}:{{ gandalf_port }}
+  rw-host: http://{{ gandalf_host_external }}:{{ gandalf_port }}
+  api-server: http://{{ gandalf_host_internal }}:{{ gandalf_port }}
 
 # S3 Bucket support. When this flag is defined as true, Tsuru will create a S3
 # bucket per application. Bucket creation depends on AWS settings (next

--- a/site.yml
+++ b/site.yml
@@ -34,10 +34,8 @@
 - hosts: api
   sudo: yes
   roles:
-    - {role: tsuru_api,
-       gandalf_host: "{{ hostvars[groups['gandalf'][0]].external_ip }}",
-       hipache_host: "{{ hostvars[groups['hipache'][0]].external_ip }}",
-       tags: tsuru_api }
+    - role: tsuru_api
+      tags: tsuru_api
 
 - hosts: gandalf
   sudo: yes

--- a/site.yml
+++ b/site.yml
@@ -43,8 +43,9 @@
   sudo: yes
   tasks:
     - name: generate tsuru token
+      run_once: true
       shell: tsr token
-      delegate_to: "{{ hostvars[groups['api'][0]].external_ip }}"
+      delegate_to: "{{ groups['api'][0] }}"
       register: tsr_token
 
     - name: write tsuru token to .bash_profile
@@ -66,4 +67,4 @@
     - name: Register node.
       shell: >
         tsuru-admin docker-node-add --register address=http://{{ internal_ip }}:{{ docker_port }}
-      delegate_to: "{{ hostvars[groups['api'][0]].external_ip }}"
+      delegate_to: "{{ groups['api'][0] }}"

--- a/ssh.config
+++ b/ssh.config
@@ -1,0 +1,20 @@
+Host nat.tsuru.paas.alphagov.co.uk 
+    User                   ec2-user
+    HostName               nat.tsuru.paas.alphagov.co.uk
+    ProxyCommand           none
+    StrictHostKeyChecking  no
+    BatchMode              yes
+    PasswordAuthentication no
+    ControlMaster          auto
+    ControlPath            ~/.ssh/mux-%r@%h:%p
+    ControlPersist         8h
+
+Host 10.128.*.*
+    ServerAliveInterval    60
+    TCPKeepAlive           yes
+    ProxyCommand           ssh -q -A ec2-user@nat.tsuru.paas.alphagov.co.uk nc %h %p
+    ControlMaster          auto
+    ControlPath            ~/.ssh/mux-%r@%h:%p
+    ControlPersist         8h
+    User                   ubuntu
+


### PR DESCRIPTION
This PR lets us use a bastion host to login to the instances, so we don't need to assign public IPs to them.
It also adds support to multiple routers instances, by using a Load balancer.
