### PR TITLE
91206714/resiliant docker registry

### DIFF
--- a/Ansiblefile
+++ b/Ansiblefile
@@ -3,7 +3,7 @@
 
 site "https://galaxy.ansible.com/api/v1"
 
-role "aalda.docker-registry", "1.0.3"
+role "aalda.docker-registry", "1.0.4"
 role "greendayonfire.mongodb", "1.2.1", github: "UnderGreen/ansible-role-mongodb"
 
 # Playbooks that are not currently in ansible-galaxy

--- a/Ansiblefile.lock
+++ b/Ansiblefile.lock
@@ -8,9 +8,9 @@ GIT
 GIT
   remote: https://github.com/codingbunch/ansible-docker-registry
   ref: master
-  sha: 33ff3ce7acd57f22b9b6bda67856be78d1e7930e
+  sha: 432e989ca0365500f40eacace3a66a8acdfe3c14
   specs:
-    aalda.docker-registry (1.0.3)
+    aalda.docker-registry (1.0.4)
 
 PATH
   remote: ./roles-static/bennojoy.redis
@@ -38,7 +38,7 @@ PATH
     tsuru_api (0.0.0)
 
 DEPENDENCIES
-  aalda.docker-registry (= 1.0.3)
+  aalda.docker-registry (= 1.0.4)
   bennojoy.redis (>= 0)
   docker_server (>= 0)
   gandalf (>= 0)

--- a/globals.yml
+++ b/globals.yml
@@ -6,8 +6,6 @@ redis_port: 6379
 tsuru_api_internal_lb: "{{ hostvars[groups['api'][0]].internal_ip }}"
 
 docker_registry_host: "{{ hostvars[groups['docker-registry'][0]].internal_ip }}"
-
-# need to be 5000 when no nginx is used.
 docker_registry_port: 6000
 docker_port: 4243
 

--- a/group_vars/docker-registry/settings
+++ b/group_vars/docker-registry/settings
@@ -1,0 +1,5 @@
+---
+registry_port: "{{ docker_registry_port }}"
+use_nginx: true
+use_redis: false
+registry_ssl: false

--- a/group_vars/docker-registry/storage_backend
+++ b/group_vars/docker-registry/storage_backend
@@ -1,0 +1,17 @@
+---
+# default storage type is local (file).
+# storage_type: "local"
+
+# storage_type: "gcs"
+gcs_bucket: "gds-docker-registry"
+gcs_storage_path: "/"
+gcs_oauth2: false
+gcs_access_key: "{{ lookup('env', 'GCS_ACCESS_KEY') }}"
+gcs_secret_key: "{{ lookup('env', 'GCS_SECRET_KEY') }}"
+
+# storage_type: "s3"
+s3_region: "eu-west-1"
+s3_bucket: "docker-registry-store"
+s3_storage_path: "/srv/docker"
+s3_access_key: "{{ lookup('env', 'AWS_ACCESS_KEY') }}"
+s3_secret_key: "{{ lookup('env', 'AWS_SECRET_KEY') }}"

--- a/site.yml
+++ b/site.yml
@@ -14,11 +14,7 @@
 - hosts: docker-registry
   sudo: yes
   roles:
-    - {role: aalda.docker-registry,
-       registry_port: "{{ docker_registry_port }}",
-       use_nginx: true,
-       use_redis: false,
-       registry_ssl: false}
+    - aalda.docker-registry
 
 # tsuru core components.
 - hosts: gandalf


### PR DESCRIPTION
Add support to setup S3 and GCS as storage backend for the docker-registry. 
When using this patch don't forget to update the docker-registry role with librarian, since it works with 1.0.4 (instead of 1.0.3).

1.0.4 adds support for GCS backend (https://github.com/codingbunch/ansible-docker-registry/commit/432e989ca0365500f40eacace3a66a8acdfe3c14)
