### PR TITLE
Reduce memory requirements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,8 @@ Vagrant.configure(2) do |config|
     v.vmx["memsize"] = MEMORY
   end
 
+  config.vm.provision :shell, inline: "apt-get purge -qq -y --auto-remove chef puppet"
+
   config.vm.define HOSTS.last[:name] do |host|
 	host.vm.provision :ansible do |ansible|
  	  ansible.raw_arguments = "--private-key=~/.vagrant.d/insecure_private_key"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,10 +2,11 @@
 # vi: set ft=ruby :
 
 INVENTORY_FILE = "inventory.vagrant"
+MEMORY_DEFAULT = 384
 HOSTS = [
-  { name: 'tsuru-i1', ip: '172.18.10.11', memory: 384,
+  { name: 'tsuru-i1', ip: '172.18.10.11',
     roles: %w{api mongodb} },
-  { name: 'tsuru-i2', ip: '172.18.10.12', memory: 384,
+  { name: 'tsuru-i2', ip: '172.18.10.12',
     roles: %w{gandalf redis-master} },
   { name: 'tsuru-i3', ip: '172.18.10.13', memory: 1024,
     roles: %w{hipache nodes docker-registry} },
@@ -51,11 +52,11 @@ Vagrant.configure(2) do |config|
       c.vm.network :private_network, ip: host[:ip]
 
       c.vm.provider :virtualbox do |v|
-        v.memory = host[:memory]
+        v.memory = host[:memory] || MEMORY_DEFAULT
       end
 
       c.vm.provider :vmware_fusion do |v|
-        v.vmx["memsize"] = host[:memory]
+        v.vmx["memsize"] = host[:memory] || MEMORY_DEFAULT
       end
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,15 +2,14 @@
 # vi: set ft=ruby :
 
 INVENTORY_FILE = "inventory.vagrant"
-MEMORY = 1024
 HOSTS = [
-  { name: 'tsuru-i1', ip: '172.18.10.11',
+  { name: 'tsuru-i1', ip: '172.18.10.11', memory: 384,
     roles: %w{api mongodb} },
-  { name: 'tsuru-i2', ip: '172.18.10.12',
+  { name: 'tsuru-i2', ip: '172.18.10.12', memory: 384,
     roles: %w{gandalf redis-master} },
-  { name: 'tsuru-i3', ip: '172.18.10.13',
+  { name: 'tsuru-i3', ip: '172.18.10.13', memory: 1024,
     roles: %w{hipache nodes docker-registry} },
-  { name: 'tsuru-i4', ip: '172.18.10.14',
+  { name: 'tsuru-i4', ip: '172.18.10.14', memory: 1024,
     roles: %w{nodes} },
 ]
 
@@ -50,15 +49,15 @@ Vagrant.configure(2) do |config|
     config.vm.define host[:name] do |c|
       c.vm.hostname = host[:name]
       c.vm.network :private_network, ip: host[:ip]
+
+      c.vm.provider :virtualbox do |v|
+        v.memory = host[:memory]
+      end
+
+      c.vm.provider :vmware_fusion do |v|
+        v.vmx["memsize"] = host[:memory]
+      end
     end
-  end
-
-  config.vm.provider :virtualbox do |v|
-    v.memory = MEMORY
-  end
-
-  config.vm.provider :vmware_fusion do |v|
-    v.vmx["memsize"] = MEMORY
   end
 
   config.vm.provision :shell, inline: "apt-get purge -qq -y --auto-remove chef puppet"


### PR DESCRIPTION
#### Remove Chef and Puppet packages from basebox

These packages are installed and their agents started by default in the
Ubuntu box that we switched to in 1cb033f. These consume some RAM that we'd
rather conserve, so remove them.

Before:

```
vagrant@tsuru-i4:~$ ps aux | grep -E 'puppet|chef'
root      1559  2.1  3.3 182492 34464 ?        Ssl  10:55   0:02 /usr/bin/ruby /usr/bin/puppet agent
root      2033  0.0  3.3 112692 34548 ?        Sl   10:55   0:00 ruby /usr/bin/chef-client -d -P /var/run/chef/client.pid -c /etc/chef/client.rb -i 1800 -s 20 -L /var/log/chef/client.log

vagrant@tsuru-i4:~$ free -m
             total       used       free     shared    buffers     cached
Mem:           993        268        725          0         12        140
-/+ buffers/cache:        115        878
Swap:            0          0          0
```

After:

```
vagrant@tsuru-i4:~$ free -m
             total       used       free     shared    buffers     cached
Mem:           993        231        762          0         20        156
-/+ buffers/cache:         54        939
Swap:            0          0          0
```
#### Reduce memory for tsuru-i1 and tsuru-i2

These nodes don't need 1G of memory. Reducing them makes it possible for me
to run all four nodes on my 8G Macbook Air.

It may be possible to reduce the docker nodes some more. However at 512M
they were unable to `tsuru-admin platform-add` for Python.

RAM available after this change:

```
(ansible)➜  tsuru-ansible git:(reduce_memory_requirements) ✗ for i in $(seq 1 4); do vagrant ssh tsuru-i${i} -c 'free -m'; done
             total       used       free     shared    buffers     cached
Mem:           363        236        127          0          9        157
-/+ buffers/cache:         69        294
Swap:            0          0          0
Connection to 127.0.0.1 closed.
             total       used       free     shared    buffers     cached
Mem:           363        127        236          0          9         74
-/+ buffers/cache:         43        320
Swap:            0          0          0
Connection to 127.0.0.1 closed.
             total       used       free     shared    buffers     cached
Mem:           993        686        307          0         12        297
-/+ buffers/cache:        375        618
Swap:            0          0          0
Connection to 127.0.0.1 closed.
             total       used       free     shared    buffers     cached
Mem:           993        229        764          0         20        156
-/+ buffers/cache:         52        941
Swap:            0          0          0
Connection to 127.0.0.1 closed.
```
