### PR TITLE
Update Router instances IPs

### DIFF
--- a/inventory-aws
+++ b/inventory-aws
@@ -1,8 +1,8 @@
 10.128.1.22     internal_ip=10.128.1.22    external_ip=api.tsuru.paas.alphagov.co.uk    name=tsuru-api
 10.128.0.127    internal_ip=10.128.0.127    external_ip=gandalf.tsuru.paas.alphagov.co.uk    name=tsuru-gandalf
 10.128.1.101     internal_ip=10.128.1.101   name=tsuru-docker
-10.128.1.127    internal_ip=10.128.1.127    external_ip=hipache.tsuru.paas.alphagov.co.uk    name=tsuru-router
-10.128.3.65     internal_ip=10.128.3.65     external_ip=hipache.tsuru.paas.alphagov.co.uk name=tsuru-router
+10.128.1.43    internal_ip=10.128.1.43    external_ip=hipache.tsuru.paas.alphagov.co.uk    name=tsuru-router
+10.128.3.238     internal_ip=10.128.3.238     external_ip=hipache.tsuru.paas.alphagov.co.uk name=tsuru-router
 
 [api]
 10.128.1.22     internal_ip=internal.api.tsuru.paas.alphagov.co.uk  name=tsuru-api
@@ -20,8 +20,8 @@
 10.128.1.207    internal_ip=10.128.1.207  name=tsuru-docker
 
 [hipache]
-10.128.1.127    internal_ip=hipache-int.tsuru.paas.alphagov.co.uk  external_ip=hipache.tsuru.paas.alphagov.co.uk name=tsuru-router
-10.128.3.65     internal_ip=hipache-int.tsuru.paas.alphagov.co.uk  external_ip=hipache.tsuru.paas.alphagov.co.uk name=tsuru-router
+10.128.1.43    internal_ip=hipache-int.tsuru.paas.alphagov.co.uk  external_ip=hipache.tsuru.paas.alphagov.co.uk name=tsuru-router
+10.128.3.238     internal_ip=hipache-int.tsuru.paas.alphagov.co.uk  external_ip=hipache.tsuru.paas.alphagov.co.uk name=tsuru-router
 
 [nodes]
 10.128.1.207    internal_ip=10.128.1.207  name=tsuru-docker


### PR DESCRIPTION
The router instances have been recreated as part of a Terraform update yesterday.
For this reason we are updating the corresponding IPs.
