### PR TITLE
Remove external_ip from postgres node

### DIFF
--- a/inventory-aws
+++ b/inventory-aws
@@ -27,7 +27,7 @@
 10.128.1.207    internal_ip=10.128.1.207  name=tsuru-docker
 
 [postgres]
-10.128.0.55     internal_ip=10.128.0.55 external_ip=52.17.185.245 name=tsuru-postgres
+10.128.0.55     internal_ip=10.128.0.55 name=tsuru-postgres
 
 [ssl-proxy]
 10.128.5.24     internal_ip=10.128.5.24 name=tsuru-ssl-proxy


### PR DESCRIPTION
This is not used so we don't need to maintain/update it.
