### PR TITLE
Remove 10.128.1.101 from AWS inventory

### DIFF
--- a/inventory-aws
+++ b/inventory-aws
@@ -1,6 +1,5 @@
 10.128.1.22     internal_ip=10.128.1.22    external_ip=api.tsuru.paas.alphagov.co.uk    name=tsuru-api
 10.128.0.127    internal_ip=10.128.0.127    external_ip=gandalf.tsuru.paas.alphagov.co.uk    name=tsuru-gandalf
-10.128.1.101     internal_ip=10.128.1.101   name=tsuru-docker
 10.128.1.43    internal_ip=10.128.1.43    external_ip=hipache.tsuru.paas.alphagov.co.uk    name=tsuru-router
 10.128.3.238     internal_ip=10.128.3.238     external_ip=hipache.tsuru.paas.alphagov.co.uk name=tsuru-router
 


### PR DESCRIPTION
This entry does not appear to be used. The entries listed under the
`[docker-registry]` and `[nodes]` roles are used instead. So remove it, in
preparation for copying this file for GCE.
