### PR TITLE
Update APT cache on ssl-proxy machines

### DIFF
--- a/ssl-proxy.yml
+++ b/ssl-proxy.yml
@@ -3,6 +3,9 @@
   roles:
     - jdauphant.nginx
   pre_tasks:
+   - name: Update APT cache
+     apt: >
+        update_cache=yes
    - name: Create Nginx Directory
      file: dest=/etc/nginx mode=755 owner=root group=root state=directory
    - name: Upload Unencrypted Key File


### PR DESCRIPTION
For AWS, our `cloud-config` scripts do a mixture of things, but almost
always run `apt-get update` when the machine first comes up.

We're not currently using `cloud-config` on GCE instances. Which means that
the install of Nginx by the `jdauphant.nginx` role fails because it doesn't
have up-to-date repo information.

We can't change the third-party role to do `update_cache=true` and it seems
that we can't change Ansible's default behaviour to always do this. I'm not
keen on the coupling between `cloud-config` so I don't think implementing
that for GCE is the right solution now. This seems to do the job.
