### PR TITLE
Install hipache from Tsuru PPA

### DIFF
--- a/roles-static/hipache/tasks/main.yml
+++ b/roles-static/hipache/tasks/main.yml
@@ -4,14 +4,9 @@
 - name: Add tsuru repositories.
   apt_repository: repo='ppa:tsuru/ppa' update_cache=yes
 
-- name: Install system packages.
+- name: Install Hipache packages.
   apt: update_cache=true name="{{ item }}"
   with_items: packages
-
-# hipache package shipped with ubuntu does not allow
-# to specify an external redis server.
-- name: Install Hipache packages with npm
-  npm: global=yes name=hipache state=present
 
 - name: copy hipache upstart script
   copy: src=hipache.upstart dest=/etc/init/hipache.conf owner=root group=root mode=0644

--- a/roles-static/hipache/vars/main.yml
+++ b/roles-static/hipache/vars/main.yml
@@ -4,3 +4,4 @@
 packages:
   - python-software-properties
   - nodejs
+  - node-hipache


### PR DESCRIPTION
This matches the current state of our AWS instances where `cloud-config`
contains the following shell commands:

```
- sudo apt-add-repository ppa:tsuru/ppa -y
- sudo apt-get update
- sudo apt-get install node-hipache -y
- sudo start hipache
```

The installation of this package before Ansible runs causes the `npm`
module, which does something like `npm list -g | grep hipache`, to think
that Hipache has already been installed.

However on GCE, where we're not currently using `cloud-config` scripts,
Ansible installs the latest version of Hipache from NPM (current 0.3.1)
which fails to start due to NodeJS errors.

By changing Ansible we should be consistent across all providers including
Vagrant. Contrary to the (removed) comment this version seems to work fine.

Along with the problem described in e950443 I am inclined that we shouldn't
use `cloud-config` on AWS in future.
