### PR TITLE
Remove extraneous entries from AWS inventory

### DIFF
--- a/inventory-aws
+++ b/inventory-aws
@@ -1,10 +1,3 @@
-10.128.1.22      internal_ip=10.128.1.22   external_ip=api.tsuru.paas.alphagov.co.uk    name=tsuru-api
-10.128.1.200     internal_ip=10.128.1.200  external_ip=api.tsuru.paas.alphagov.co.uk    name=tsuru-api
-10.128.3.7       internal_ip=10.128.3.7    external_ip=api.tsuru.paas.alphagov.co.uk    name=tsuru-api
-10.128.0.127    internal_ip=10.128.0.127    external_ip=gandalf.tsuru.paas.alphagov.co.uk    name=tsuru-gandalf
-10.128.1.43    internal_ip=10.128.1.43    external_ip=hipache.tsuru.paas.alphagov.co.uk    name=tsuru-router
-10.128.3.238     internal_ip=10.128.3.238     external_ip=hipache.tsuru.paas.alphagov.co.uk name=tsuru-router
-
 [api]
 10.128.1.200     internal_ip=internal.api.tsuru.paas.alphagov.co.uk  name=tsuru-api
 10.128.3.7       internal_ip=internal.api.tsuru.paas.alphagov.co.uk  name=tsuru-api


### PR DESCRIPTION
@jimconner and I talked about why we have these entries duplicated at the
top of the inventory file and within each role. Some are only listed within
roles. We couldn't find a reason why and removing them doesn't appear to
make any difference when running `ansible-playbook` against a new cluster.
So remove them and make it easier to maintain.
