### PR TITLE
[#91206264] Added delegation so that admin user team changes are run from mongo

### DIFF
--- a/globals.yml
+++ b/globals.yml
@@ -4,6 +4,7 @@ redis_host: "{{ hostvars[groups['redis-master'][0]].internal_ip }}"
 redis_port: 6379
 
 tsuru_api_internal_lb: "{{ hostvars[groups['api'][0]].internal_ip }}"
+api_port: 8080
 
 docker_registry_host: "{{ hostvars[groups['docker-registry'][0]].internal_ip }}"
 docker_registry_port: 6000

--- a/roles-static/tsuru_api/defaults/main.yml
+++ b/roles-static/tsuru_api/defaults/main.yml
@@ -1,8 +1,3 @@
 ---
 # defaults file for tsuru_api
 
-api_port: 8080
-mongodb_port: 27017
-gandalf_port: 8080
-redis_port: 6379
-docker_port: 4243

--- a/roles-static/tsuru_api/tasks/main.yml
+++ b/roles-static/tsuru_api/tasks/main.yml
@@ -30,19 +30,3 @@
 
 - name: Wait for tsuru-server to be up
   wait_for: port={{api_port}} timeout=60
-
-# TODO: handle the case where the user already exists
-- name: Add admin user team
-  shell: >
-    mongo tsuru --eval 'db.teams.update({_id: "admin"}, {_id: "admin"}, {upsert: true})';
-    mongo tsuru --eval "db.teams.update({_id: 'admin'}, {\$addToSet: {users: '{{admin_user}}'}})";
-  delegate_to: "{{ groups['mongodb'][0] }}"
-  
-- name: Add admin user.
-  shell: >
-    curl -sS -XPOST -d"{\"email\":\"{{admin_user}}\",\"password\":\"{{admin_password}}\"}" "http://127.0.0.1:{{api_port}}/users"
-
-- name: Login with the admin user.
-  shell: >
-    token=$(curl -sS -XPOST -d"{\"password\":\"{{admin_password}}\"}" "http://127.0.0.1:{{api_port}}/users/{{admin_user}}/tokens" | jq -r .token);
-    echo "${token}" > ~/.tsuru_token

--- a/roles-static/tsuru_api/tasks/main.yml
+++ b/roles-static/tsuru_api/tasks/main.yml
@@ -32,13 +32,17 @@
   wait_for: port={{api_port}} timeout=60
 
 # TODO: handle the case where the user already exists
-- name: Add admin user.
+- name: Add admin user team
   shell: >
     mongo tsuru --eval 'db.teams.update({_id: "admin"}, {_id: "admin"}, {upsert: true})';
     mongo tsuru --eval "db.teams.update({_id: 'admin'}, {\$addToSet: {users: '{{admin_user}}'}})";
+  delegate_to: "{{ groups['mongodb'][0] }}"
+  
+- name: Add admin user.
+  shell: >
     curl -sS -XPOST -d"{\"email\":\"{{admin_user}}\",\"password\":\"{{admin_password}}\"}" "http://127.0.0.1:{{api_port}}/users"
 
-- name: Login with the admon user.
+- name: Login with the admin user.
   shell: >
     token=$(curl -sS -XPOST -d"{\"password\":\"{{admin_password}}\"}" "http://127.0.0.1:{{api_port}}/users/{{admin_user}}/tokens" | jq -r .token);
     echo "${token}" > ~/.tsuru_token

--- a/site.yml
+++ b/site.yml
@@ -33,6 +33,33 @@
     - role: tsuru_api
       tags: tsuru_api
 
+- hosts: api
+  sudo: yes
+  tasks:
+    - name: add admin team
+      run_once: true
+      shell: >
+        mongo tsuru --eval 'db.teams.update({_id: "admin"}, {_id: "admin"}, {upsert: true})';
+      delegate_to: "{{ groups['mongodb'][0] }}"
+
+    - name: add admin user to admin team
+      run_once: true
+      shell: >
+        mongo tsuru --eval "db.teams.update({_id: 'admin'}, {\$addToSet: {users: '{{admin_user}}'}})";
+      delegate_to: "{{ groups['mongodb'][0] }}"
+
+# TODO : handle the case where the user already exists
+    - name: add admin user
+      run_once: true
+      shell: >
+        curl -sS -XPOST -d"{\"email\":\"{{admin_user}}\",\"password\":\"{{admin_password}}\"}" "http://127.0.0.1:{{api_port}}/users"
+
+    - name: login with the admin user
+      run_once: true
+      shell: >
+        token=$(curl -sS -XPOST -d"{\"password\":\"{{admin_password}}\"}" "http://127.0.0.1:{{api_port}}/users/{{admin_user}}/tokens" | jq -r .token);
+        echo "${token}" > ~/.tsuru_token
+
 - hosts: gandalf
   sudo: yes
   tasks:


### PR DESCRIPTION
API and mongo are no longer supposed to be running on the same instance,
mongo-clients is not installed on the api instances and the mongo server
needs to be address to add necessary modifications to admin user teams.

The operation on mongo is nog delegated to the appropriate mongo
instance (the first mongo instance that is present)
