### PR TITLE
Workaround hipache bug when IPv6 is disabled

### DIFF
--- a/roles-static/hipache/templates/hipache.conf.j2
+++ b/roles-static/hipache/templates/hipache.conf.j2
@@ -2,6 +2,9 @@
     "server": {
         "debug": true,
         "accessLog": "/var/log/hipache/access.log",
+{% if ansible_all_ipv6_addresses == [] %}
+        "address6": [],
+{% endif %}
         "port": 80,
         "workers": 5,
         "maxSockets": 100,


### PR DESCRIPTION
Unlike AWS our GCE instances don't have IPv6 support enabled by default
(there are no link-local addresses). A bug in Hipache causes workers to die
when they attempt to listen on `::1`. The following errors gets repeated:

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: bind EADDRNOTAVAIL
    at errnoException (net.js:904:11)
    at net.js:1072:30
    at Object.2345:2 (cluster.js:592:5)
    at handleResponse (cluster.js:171:41)
    at respond (cluster.js:192:5)
    at handleMessage (cluster.js:202:5)
    at process.EventEmitter.emit (events.js:117:20)
    at handleMessage (child_process.js:318:10)
    at Pipe.channel.onread (child_process.js:345:11)
29 Apr 09:44:22 - Worker died (pid: 16453, suicide: false, exitcode: 8). Spawning a new one.
```

Fix this by explicitly not binding to any v6 addresses when Ansible's fact
hasn't registered any.
