### PR TITLE
Wrapper script for vault password

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,13 @@ bundle exec librarian-ansible install
 ssh-add <the-public-ssh-key-file>
 ```
 * Tune any global configuration needed to run your cluster in group_vars/all/globals.yml
-* Run ansible to deploy your configuration.
 
-For AWS deployment:
+### Deploying
+
+Run:
 ```{r, engine='bash'}
-ansible-playbook -i inventory site-aws.yml --ask-vault-pass
-```
-For GCE deployment:
-```{r, engine='bash'}
-ansible-playbook -i inventory site-gce.yml --ask-vault-pass
+ansible-playbook -i inventory-<PROVIDER_NAME> site-<PROVIDER_NAME>.yml --ask-vault-pass
 ```
 
-For Vagrant deployment:
-```{r, engine='bash'}
-ansible-playbook -i inventory site-vagrant.yml --ask-vault-pass
-```
-
+Where:
+  - `<PROVIDER_NAME>` is: `aws`, `gce` or `vagrant`

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ ssh-add <the-public-ssh-key-file>
 
 Run:
 ```{r, engine='bash'}
-ansible-playbook -i inventory-<PROVIDER_NAME> site-<PROVIDER_NAME>.yml --ask-vault-pass
+ansible-playbook -i inventory-<PROVIDER_NAME> site-<PROVIDER_NAME>.yml --vault-password-file vault_password.sh
 ```
 
 Where:

--- a/vault_password.sh
+++ b/vault_password.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eu
+
+KEYCHAIN_ACCOUNT_NAME="tsuru-ansible-vault"
+
+if which security >/dev/null; then
+  >&2 echo "Fetching vault password from account '${KEYCHAIN_ACCOUNT_NAME}' in keychain.."
+  security find-generic-password -wa ${KEYCHAIN_ACCOUNT_NAME}
+else
+  >&2 echo "Keychain not available. Prompting for vault password interatively.."
+  >&2 echo -n "Vault password: "
+  read -s PASSWORD
+  >&2 echo
+  echo $PASSWORD
+fi


### PR DESCRIPTION
On Mac OS X this will attempt to fetch the password from the keychain. This
is more secure than storing the password in a plaintext file on the
filesystem.

On Linux it will fallback to an interactive prompt which is effectively the
same as `--ask-vault-pass` but allows us to simplify our run instructions by
using the same argument regardless.

When the argument to `--vault-password-file` is an executable then Ansible
will run it an obtain the password from STDOUT.

---

This supersedes #35
