### PR TITLE
Corrected name of the storage_path variable:

### DIFF
--- a/site-aws.yml
+++ b/site-aws.yml
@@ -7,7 +7,7 @@
     storage_type: "s3"
     s3_region: "eu-west-1"
     s3_bucket: "mcp.registry.storage"
-    s3_storage_path: "/"
+    storage_path: "/"
 
   roles:
     - aalda.docker-registry


### PR DESCRIPTION
The storage path variable is not storage type specific in the
aalda.docker-registry role. Therefore no s3_storage_path exists.

This change lets docker images be saved under the root of the
cluster-specific bucket instaed than <bucketname>/var/docker-registry

The same variable may be used, if desired, to use the same bucket for
more clusters (each in its own subtree)

For more info, variables (and their defaults) are defined into
roles/aalda.docker-registry/templates/config.yml.j2
