### PR TITLE
Vendor git pre-receive hook

### DIFF
--- a/roles-static/gandalf/defaults/main.yml
+++ b/roles-static/gandalf/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for gandalf
 
 gandalf_port: 8080
+gandalf_git_template_dir: /home/git/bare-template

--- a/roles-static/gandalf/files/pre-receive.archive-server
+++ b/roles-static/gandalf/files/pre-receive.archive-server
@@ -1,0 +1,62 @@
+#!/bin/bash -el
+
+# This script uses the archive-server (https://github.com/tsuru/archive-server)
+# to generate archives and deploy applications using them.
+#
+# It depends on the following environment variables:
+#
+#   - ARCHIVE_SERVER_READ: the base URL that will be sent to the tsuru server,
+#                          is a public URL that will be used to serve the
+#                          archive (for example: http://archive-server:8080)
+#   - ARCHIVE_SERVER_WRITE: the base URL that will be used to generate the
+#                           archive, it's commonly a private URL (for example:
+#                           http://127.0.0.1:8181)
+#   - TSURU_HOST: URL to the Tsuru API (for example: http://yourtsuru:8080)
+#   - TSURU_TOKEN: the token to communicate with the API (generated with `tsr
+#                  token`, in the server).
+
+while read oldrev newrev refname
+do
+        set +e
+        echo $refname | grep -q /master$
+        status=$?
+        set -e
+        if [ $status = 0 ]
+        then
+                COMMIT=${newrev}
+        fi
+done
+
+if [ -z ${COMMIT} ]
+then
+	echo "ERROR: please push to master"
+	exit 3
+fi
+
+generate_archive() {
+	url="${ARCHIVE_SERVER_WRITE}/"
+	result=`curl -sNd "path=${1}&refid=${2}" $url`
+	python <<END
+import json
+print json.loads(u"""${result}""")["id"]
+END
+}
+
+wait_archive() {
+        url="${1}&keep=1"
+        content_type=`curl -sI $url | grep Content-Type | awk '{print $2}'`
+        while echo $content_type | grep -v application/x-gzip
+        do
+                sleep 1
+                content_type=`curl -sI $url | grep Content-Type | awk '{print $2}'`
+        done
+}
+
+APP_DIR=${PWD##*/}
+APP_NAME=${APP_DIR/.git/}
+archive_id=`generate_archive $PWD $COMMIT`
+archive_url="${ARCHIVE_SERVER_READ}/?id=$archive_id"
+wait_archive $archive_url
+url="${TSURU_HOST}/apps/${APP_NAME}/repository/clone"
+curl -H "Authorization: bearer ${TSURU_TOKEN}" -d "archive-url=${archive_url}&commit=${COMMIT}&user=${TSURU_USER}" -s -N $url | tee /tmp/deploy-${APP_NAME}.log
+tail -1 /tmp/deploy-${APP_NAME}.log | grep -q "^OK$"

--- a/roles-static/gandalf/tasks/main.yml
+++ b/roles-static/gandalf/tasks/main.yml
@@ -9,10 +9,10 @@
   with_items: packages
 
 - name: Create git hook directory.
-  file: path=/home/git/bare-template/hooks state=directory owner=git group=git recurse=yes
+  file: path={{ gandalf_git_template_dir }}/hooks state=directory owner=git group=git recurse=yes
 
 - name: Install git hook.
-  copy: src=pre-receive.archive-server dest=/home/git/bare-template/hooks/pre-receive owner=git group=git mode=0755
+  copy: src=pre-receive.archive-server dest={{ gandalf_git_template_dir }}/hooks/pre-receive owner=git group=git mode=0755
 
 - name: Add archive server to bash profile.
   lineinfile: 'create=yes dest=/home/git/.bash_profile line="export ARCHIVE_SERVER_READ=http://{{gandalf_host_internal}}:3232 ARCHIVE_SERVER_WRITE=http://127.0.0.1:3131"'

--- a/roles-static/gandalf/tasks/main.yml
+++ b/roles-static/gandalf/tasks/main.yml
@@ -8,12 +8,11 @@
   apt: update_cache=true name="{{ item }}"
   with_items: packages
 
-- name: Configure git hook.
-  shell: >
-    mkdir -p /home/git/bare-template/hooks;
-    curl https://raw.githubusercontent.com/tsuru/tsuru/master/misc/git-hooks/pre-receive.archive-server -o /home/git/bare-template/hooks/pre-receive;
-    chmod +x /home/git/bare-template/hooks/pre-receive;
-    chown -R git:git /home/git/bare-template;
+- name: Create git hook directory.
+  file: path=/home/git/bare-template/hooks state=directory owner=git group=git recurse=yes
+
+- name: Install git hook.
+  copy: src=pre-receive.archive-server dest=/home/git/bare-template/hooks/pre-receive owner=git group=git mode=0755
 
 - name: Add archive server to bash profile.
   lineinfile: 'create=yes dest=/home/git/.bash_profile line="export ARCHIVE_SERVER_READ=http://{{gandalf_host_internal}}:3232 ARCHIVE_SERVER_WRITE=http://127.0.0.1:3131"'

--- a/roles-static/gandalf/templates/gandalf.conf.j2
+++ b/roles-static/gandalf/templates/gandalf.conf.j2
@@ -14,7 +14,7 @@ database:
 git:
   bare:
     location: /var/lib/gandalf/repositories
-    template: /home/git/bare-template
+    template: {{ gandalf_git_template_dir }}
 
 # Path to the authorized_keys file.
 #


### PR DESCRIPTION
Instead of fetching it from the Internet. This will protect us against
GitHub being down or the script changing and being inconsistent across
environments.

It also means that we're no longer using inline shell script. Which Ansible
was giving us a warning about and we wouldn't have been capturing exit codes
if anything but the last command failed.

The file is taken from this upstream:

https://github.com/tsuru/tsuru/blob/e0699f287dce9a48e3b727a939bb179df5e7e98c/misc/git-hooks/pre-receive.archive-server

This change is a noop when applied to an existing machine. I'm still able to
deploy an app when this is applied to a new Gandalf machine.
