### PR TITLE
Check for AWS environment variables in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ all:
 	$(error Usage: make <aws|gce> DEPLOY_ENV=name [ARGS=extra_args])
 
 aws: check-env-var render-ssh-config
+ifndef AWS_SECRET_ACCESS_KEY
+	$(error Environment variable AWS_SECRET_ACCESS_KEY must be set)
+endif
+ifndef AWS_ACCESS_KEY_ID
+	$(error Environment variable AWS_ACCESS_KEY_ID must be set)
+endif
 	ansible-playbook -i ec2.py --vault-password-file vault_password.sh site-aws.yml -e "deploy_env=${DEPLOY_ENV}" -e "@platform-aws.yml" ${ARGS}
 
 gce: check-env-var render-ssh-config


### PR DESCRIPTION
To compliment the README and give a more helpful error message than the
following when you haven't set the environment variables for your AWS access
keys:

```
(ansible)➜  tsuru-ansible git:(makefile_aws_env_vars) ✗ make aws DEPLOY_ENV=foo
sed "s/DEPLOY_ENV/foo/g" ssh.config.template > ssh.config
ansible-playbook -i ec2.py --vault-password-file vault_password.sh site-aws.yml -e "deploy_env=foo" -e "@platform-aws.yml"
Fetching vault password from account 'tsuru-ansible-vault' in keychain..
ERROR: Inventory script (ec2.py) had an execution error: Traceback (most recent call last):
  File "/Users/dcarley/projects/paas/tsuru-ansible/ec2.py", line 722, in <module>
    Ec2Inventory()
  File "/Users/dcarley/projects/paas/tsuru-ansible/ec2.py", line 156, in __init__
    self.do_api_calls_update_cache()
  File "/Users/dcarley/projects/paas/tsuru-ansible/ec2.py", line 303, in do_api_calls_update_cache
    self.get_instances_by_region(region)
  File "/Users/dcarley/projects/paas/tsuru-ansible/ec2.py", line 320, in get_instances_by_region
    conn = ec2.connect_to_region(region)
  File "/Users/dcarley/.virtualenvs/ansible/lib/python2.7/site-packages/boto/ec2/__init__.py", line 66, in connect_to_region
    return region.connect(**kw_params)
  File "/Users/dcarley/.virtualenvs/ansible/lib/python2.7/site-packages/boto/regioninfo.py", line 187, in connect
    return self.connection_cls(region=self, **kw_params)
  File "/Users/dcarley/.virtualenvs/ansible/lib/python2.7/site-packages/boto/ec2/connection.py", line 103, in __init__
    profile_name=profile_name)
  File "/Users/dcarley/.virtualenvs/ansible/lib/python2.7/site-packages/boto/connection.py", line 1100, in __init__
    provider=provider)
  File "/Users/dcarley/.virtualenvs/ansible/lib/python2.7/site-packages/boto/connection.py", line 569, in __init__
    host, config, self.provider, self._required_auth_capability())
  File "/Users/dcarley/.virtualenvs/ansible/lib/python2.7/site-packages/boto/auth.py", line 987, in get_auth_handler
    'Check your credentials' % (len(names), str(names)))
boto.exception.NoAuthHandlerFound: No handler was ready to authenticate. 1 handlers were checked. ['HmacAuthV4Handler'] Check your credentials

make: *** [aws] Error 1
```
