### PR TITLE
Use LB for internal access to API

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -60,7 +60,7 @@
     - name: generate tsuru token
       run_once: true
       shell: tsr token
-      delegate_to: "{{ tsuru_api_internal_lb }}"
+      delegate_to: "{{ tsuru_api_host }}"
       register: tsr_token
 
     - name: write tsuru token to .bash_profile
@@ -82,12 +82,12 @@
     - name: Register node.
       shell: >
         tsuru-admin docker-node-add --register address=http://{{ gce_private_ip }}:{{ docker_port }}
-      delegate_to: "{{ tsuru_api_internal_lb }}"
+      delegate_to: "{{ tsuru_api_host }}"
       when: gce_private_ip is defined
     - name: Register node.
       shell: >
         tsuru-admin docker-node-add --register address=http://{{ ec2_private_ip_address }}:{{ docker_port }}
-      delegate_to: "{{ tsuru_api_internal_lb }}"
+      delegate_to: "{{ tsuru_api_host }}"
       when: ec2_private_ip_address is defined
 
 - include: postgres.yml

--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -5,8 +5,9 @@ domain_name: "tsuru.paas.alphagov.co.uk"
 redis_host_name: "tag_Name_{{ deploy_env }}-tsuru-db"
 redis_host: "{{ hostvars[groups[redis_host_name][0]][ip_field_name] }}"
 
-tsuru_api_name: "tag_Name_{{ deploy_env }}-tsuru-api"
-tsuru_api_internal_lb: "{{ hostvars[groups[tsuru_api_name][0]][ip_field_name] }}"
+tsuru_api_host_name: "tag_Name_{{ deploy_env }}-tsuru-api"
+tsuru_api_host: "{{ hostvars[groups[tsuru_api_host_name][0]][ip_field_name] }}"
+tsuru_api_internal_lb: "{{ deploy_env }}-api-int.{{ domain_name }}"
 
 docker_registry_name: "tag_Name_{{ deploy_env }}-tsuru-registry"
 docker_registry_host: "{{ hostvars[groups[docker_registry_name][0]][ip_field_name] }}"

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -5,8 +5,9 @@ domain_name: "tsuru2.paas.alphagov.co.uk"
 redis_host_name: "{{ deploy_env }}-tsuru-db"
 redis_host: "{{ hostvars[redis_host_name][ip_field_name] }}"
 
-tsuru_api_name: "{{ deploy_env }}-tsuru-api-0"
-tsuru_api_internal_lb: "{{ hostvars[tsuru_api_name][ip_field_name] }}"
+tsuru_api_host_name: "{{ deploy_env }}-tsuru-api-0"
+tsuru_api_host: "{{ hostvars[tsuru_api_host_name][ip_field_name] }}"
+tsuru_api_internal_lb: "{{ deploy_env }}-api.{{ domain_name }}"
 
 hipache_host_internal_lb: "{{ deploy_env }}-hipache.{{ domain_name }}"
 


### PR DESCRIPTION
A regression was introduced in the dynamic inventory work (not a surprise
because it was very complex - alphagov/tsuru-ansible#41) which meant that we
stopped using the load balancer for internal access to the API and only used
the first instance.

For example on the Gandalf host:

```
ubuntu@ip-10-128-10-180:~$ grep TSURU_HOST /home/git/.bash_profile
export TSURU_HOST=http://10.128.13.209:8080
```

Re-purpose the values with new key names to use as a variable for delegating
to the first API node and re-purpose the key name to be the DNS name of the
load balancer. This has a different hostname on AWS which is dependent on
the renaming in alphagov/tsuru-terraform#52
