### PR TITLE
[#93690844] Address registry using DNS again

### DIFF
--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -4,6 +4,7 @@ redis_port: 6379
 
 api_port: 8080
 
+docker_registry_host: "{{ deploy_env }}-docker-registry.{{ domain_name }}"
 docker_registry_port: 6000
 docker_port: 4243
 

--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -8,9 +8,6 @@ redis_host: "{{ hostvars[groups[redis_host_name][0]][ip_field_name] }}"
 tsuru_api_name: "tag_Name_{{ deploy_env }}-tsuru-api"
 tsuru_api_internal_lb: "{{ hostvars[groups[tsuru_api_name][0]][ip_field_name] }}"
 
-docker_registry_name: "tag_Name_{{ deploy_env }}-tsuru-registry"
-docker_registry_host: "{{ hostvars[groups[docker_registry_name][0]][ip_field_name] }}"
-
 hipache_host_internal_lb: "{{ deploy_env }}-hipache-int.{{ domain_name }}"
 
 gandalf_host_name: "tag_Name_{{ deploy_env }}-tsuru-gandalf"

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -10,10 +10,6 @@ tsuru_api_internal_lb: "{{ hostvars[tsuru_api_name][ip_field_name] }}"
 
 hipache_host_internal_lb: "{{ deploy_env }}-hipache.{{ domain_name }}"
 
-docker_registry_name: "{{ deploy_env }}-tsuru-registry"
-docker_registry_host: "{{ hostvars[docker_registry_name][ip_field_name] }}"
-docker_registry_port: 6000
-
 gandalf_host_name: "{{ deploy_env }}-tsuru-gandalf"
 gandalf_host_internal: "{{ hostvars[gandalf_host_name][ip_field_name] }}"
 gandalf_host_external: "{{ deploy_env }}-gandalf.{{ domain_name }}"


### PR DESCRIPTION
A regression was introduced in the dynamic inventory work (not a surprise
because it was very complex - alphagov/tsuru-ansible#41) which meant that we
went back to address the Docker registry by IP instead of hostname. This
causes problems when the IP of the registry machine is changed because
images are namespaced by the registry that they come from.

Go back to using DNS like we did in 42e3bfb1dc0bf1a7935917ff0d4e574ab29fe332
for the (then) static inventory.

I'm also removing the duplicate entry for `docker_registry_port`. We only
need the entry in globals, for both platforms.
