### PR TITLE
Restrict AWS inventory to European regions

### DIFF
--- a/ec2.ini
+++ b/ec2.ini
@@ -11,8 +11,8 @@
 # AWS regions to make calls to. Set this to 'all' to make request to all regions
 # in AWS and merge the results together. Alternatively, set this to a comma
 # separated list of regions. E.g. 'us-east-1,us-west-1,us-west-2'
-regions = all
-regions_exclude = us-gov-west-1,cn-north-1
+regions = eu-west-1,eu-central-1
+regions_exclude =
 
 # When generating inventory, Ansible needs to know how to address a server.
 # Each EC2 instance has a lot of variables associated with it. Here is the list:


### PR DESCRIPTION
Per the configs in alphagov/tsuru-terraform we're only using `eu-west-1` at
the moment and the only region that we're likely to extend into is
`eu-central-1` because we need data to be located within Europe.

Restricting the regions we search brings the uncached time down from 15~30
seconds:

```
(ansible)➜  tsuru-ansible git:(master) time ./ec2.py --refresh-cache >/dev/null
./ec2.py --refresh-cache > /dev/null  0.52s user 0.07s system 1% cpu 29.801 total
(ansible)➜  tsuru-ansible git:(master) time ./ec2.py --refresh-cache >/dev/null
./ec2.py --refresh-cache > /dev/null  0.51s user 0.07s system 3% cpu 14.910 total
```

To ~1 second:

```
(ansible)➜  tsuru-ansible git:(ec2_restrict_regions) time ./ec2.py --refresh-cache >/dev/null
./ec2.py --refresh-cache > /dev/null  0.22s user 0.05s system 26% cpu 1.020 total
(ansible)➜  tsuru-ansible git:(ec2_restrict_regions) time ./ec2.py --refresh-cache >/dev/null
./ec2.py --refresh-cache > /dev/null  0.22s user 0.05s system 32% cpu 0.854 total
```
