### PR TITLE
Update hostname to tag/regex format for dual-cloud deploy

### DIFF
--- a/postgres.yml
+++ b/postgres.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: postgres
+- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-postgres
   sudo: yes
   sudo_user: root
   roles:


### PR DESCRIPTION
It seems that we overlooked the postgres server name during our
rework for dual-cloud compatibility.
