### PR TITLE
Remove dupe gandalf_host_external vars

### DIFF
--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -13,7 +13,6 @@ hipache_host_internal_lb: "{{ deploy_env }}-hipache-int.{{ domain_name }}"
 
 gandalf_host_name: "tag_Name_{{ deploy_env }}-tsuru-gandalf"
 gandalf_host_internal: "{{ hostvars[groups[gandalf_host_name][0]][ip_field_name] }}"
-gandalf_host_external: "{{ deploy_env }}-gandalf.{{ domain_name }}"
 
 mongodb_host_name: "tag_Name_{{ deploy_env }}-tsuru-db"
 mongodb_host: "{{ hostvars[groups[mongodb_host_name][0]][ip_field_name] }}"

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -13,7 +13,6 @@ hipache_host_internal_lb: "{{ deploy_env }}-hipache.{{ domain_name }}"
 
 gandalf_host_name: "{{ deploy_env }}-tsuru-gandalf"
 gandalf_host_internal: "{{ hostvars[gandalf_host_name][ip_field_name] }}"
-gandalf_host_external: "{{ deploy_env }}-gandalf.{{ domain_name }}"
 
 mongodb_host_name: "{{ deploy_env }}-tsuru-db"
 mongodb_host: "{{ hostvars[mongodb_host_name][ip_field_name] }}"


### PR DESCRIPTION
The value is the same for both providers and is also defined in
`group_vars/all/globals.yml`, so we don't need to specify it in the provider
specific var files.
