### PR TITLE
Abstract difference in AWS/GCE tags

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1,33 +1,33 @@
 # Bring up db tier (redis, mongodb).
-- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-db
+- hosts: "{{ hosts_prefix }}-tsuru-db"
   sudo: yes
   roles:
     - bennojoy.redis
 
-- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-db
+- hosts: "{{ hosts_prefix }}-tsuru-db"
   sudo: yes
   sudo_user: root
   roles:
     - greendayonfire.mongodb
 
 # tsuru core components.
-- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-gandalf*
+- hosts: "{{ hosts_prefix }}-tsuru-gandalf*"
   sudo: yes
   roles:
     - gandalf
 
-- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-router*
+- hosts: "{{ hosts_prefix }}-tsuru-router*"
   sudo: yes
   roles:
     - hipache
 
-- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-api*
+- hosts: "{{ hosts_prefix }}-tsuru-api*"
   sudo: yes
   roles:
     - role: tsuru_api
       tags: tsuru_api
 
-- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-api*
+- hosts: "{{ hosts_prefix }}-tsuru-api*"
   sudo: yes
   tasks:
     - name: add admin team
@@ -54,7 +54,7 @@
         token=$(curl -sS -XPOST -d"{\"password\":\"{{admin_password}}\"}" "http://127.0.0.1:{{api_port}}/users/{{admin_user}}/tokens" | jq -r .token);
         echo "${token}" > ~/.tsuru_token
 
-- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-gandalf*
+- hosts: "{{ hosts_prefix }}-tsuru-gandalf*"
   sudo: yes
   tasks:
     - name: generate tsuru token
@@ -73,7 +73,7 @@
     - name: restart gandalf
       service: name=gandalf-server state=restarted
 
-- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-docker*
+- hosts: "{{ hosts_prefix }}-tsuru-docker*"
   sudo: yes
   roles:
     - docker_server

--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -1,18 +1,19 @@
 ---
 ip_field_name: "ec2_private_ip_address"
 domain_name: "tsuru.paas.alphagov.co.uk"
+hosts_prefix: "tag_Name_{{ deploy_env }}"
 
-redis_host_name: "tag_Name_{{ deploy_env }}-tsuru-db"
+redis_host_name: "{{ hosts_prefix }}-tsuru-db"
 redis_host: "{{ hostvars[groups[redis_host_name][0]][ip_field_name] }}"
 
-tsuru_api_host_name: "tag_Name_{{ deploy_env }}-tsuru-api"
+tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api"
 tsuru_api_host: "{{ hostvars[groups[tsuru_api_host_name][0]][ip_field_name] }}"
 tsuru_api_internal_lb: "{{ deploy_env }}-api-int.{{ domain_name }}"
 
 hipache_host_internal_lb: "{{ deploy_env }}-hipache-int.{{ domain_name }}"
 
-gandalf_host_name: "tag_Name_{{ deploy_env }}-tsuru-gandalf"
+gandalf_host_name: "{{ hosts_prefix }}-tsuru-gandalf"
 gandalf_host_internal: "{{ hostvars[groups[gandalf_host_name][0]][ip_field_name] }}"
 
-mongodb_host_name: "tag_Name_{{ deploy_env }}-tsuru-db"
+mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
 mongodb_host: "{{ hostvars[groups[mongodb_host_name][0]][ip_field_name] }}"

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -1,18 +1,19 @@
 ---
 ip_field_name: "gce_private_ip"
 domain_name: "tsuru2.paas.alphagov.co.uk"
+hosts_prefix: "{{ deploy_env }}"
 
-redis_host_name: "{{ deploy_env }}-tsuru-db"
+redis_host_name: "{{ hosts_prefix }}-tsuru-db"
 redis_host: "{{ hostvars[redis_host_name][ip_field_name] }}"
 
-tsuru_api_host_name: "{{ deploy_env }}-tsuru-api-0"
+tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api-0"
 tsuru_api_host: "{{ hostvars[tsuru_api_host_name][ip_field_name] }}"
-tsuru_api_internal_lb: "{{ deploy_env }}-api.{{ domain_name }}"
+tsuru_api_internal_lb: "{{ hosts_prefix }}-api.{{ domain_name }}"
 
-hipache_host_internal_lb: "{{ deploy_env }}-hipache.{{ domain_name }}"
+hipache_host_internal_lb: "{{ hosts_prefix }}-hipache.{{ domain_name }}"
 
-gandalf_host_name: "{{ deploy_env }}-tsuru-gandalf"
+gandalf_host_name: "{{ hosts_prefix }}-tsuru-gandalf"
 gandalf_host_internal: "{{ hostvars[gandalf_host_name][ip_field_name] }}"
 
-mongodb_host_name: "{{ deploy_env }}-tsuru-db"
+mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
 mongodb_host: "{{ hostvars[mongodb_host_name][ip_field_name] }}"

--- a/postgres.yml
+++ b/postgres.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-postgres
+- hosts: "{{ hosts_prefix }}-tsuru-postgres"
   sudo: yes
   sudo_user: root
   roles:

--- a/site-aws.yml
+++ b/site-aws.yml
@@ -1,7 +1,7 @@
 ---
 
 # AWS-Specific variables and steps.
-- hosts: "tag_Name_{{ deploy_env }}-tsuru-registry*"
+- hosts: "{{ hosts_prefix }}-tsuru-registry*"
   sudo: yes
   vars:
     registry_port: "{{ docker_registry_port }}"

--- a/site-gce.yml
+++ b/site-gce.yml
@@ -1,7 +1,7 @@
 ---
 
 # AWS-Specific variables and steps.
-- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-registry
+- hosts: "{{ hosts_prefix }}-tsuru-registry"
   sudo: yes
   vars:
     storage_type: "local"

--- a/ssl-proxy.yml
+++ b/ssl-proxy.yml
@@ -1,4 +1,4 @@
-- hosts: ~({{ deploy_env }}|tag_Name_{{ deploy_env }})-tsuru-sslproxy*
+- hosts: "{{ hosts_prefix }}-tsuru-sslproxy*"
   sudo: yes
   roles:
     - jdauphant.nginx


### PR DESCRIPTION
By using an intermediate variable. This doesn't allow us to de-dupe any
variables, but it does make the `hosts` entries much easier to read and mean
that we don't need to use regexps (which are error prone).

I've tested this with the following commands and verified that the lists of
hosts under each "play" remain the same:

```
time make aws DEPLOY_ENV=dcarley ARGS=--list-hosts
time make gce DEPLOY_ENV=dcarley ARGS=--list-hosts
```
