### PR TITLE
Replace curl commands with Ansible uri module

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -48,14 +48,24 @@
 # TODO : handle the case where the user already exists
     - name: add admin user
       run_once: true
-      shell: >
-        curl -sS -XPOST -d"{\"email\":\"{{admin_user}}\",\"password\":\"{{admin_password}}\"}" "http://127.0.0.1:{{api_port}}/users"
+      uri:
+        method=POST body_format=json
+        body="{\"email\":\"{{ admin_user }}\",\"password\":\"{{ admin_password }}\"}"
+        url=http://127.0.0.1:{{ api_port }}/users
+        status_code=201
 
     - name: login with the admin user
       run_once: true
-      shell: >
-        token=$(curl -sS -XPOST -d"{\"password\":\"{{admin_password}}\"}" "http://127.0.0.1:{{api_port}}/users/{{admin_user}}/tokens" | jq -r .token);
-        echo "${token}" > ~/.tsuru_token
+      uri:
+        method=POST body_format=json
+        body="{\"password\":\"{{ admin_password }}\"}"
+        url=http://127.0.0.1:{{ api_port }}/users/{{ admin_user }}/tokens
+        return_content=yes
+      register: login_response
+
+    - name: write admin token
+      run_once: true
+      copy: dest=~/.tsuru_token mode=0600 content="{{ (login_response.content|from_json).token }}"
 
 - hosts: "{{ hosts_prefix }}-tsuru-gandalf*"
   sudo: yes

--- a/common.yml
+++ b/common.yml
@@ -30,6 +30,9 @@
 - hosts: "{{ hosts_prefix }}-tsuru-api*"
   sudo: yes
   tasks:
+    - name: Install httplib2 for Ansible uri module
+      apt: name=python-httplib2 state=present
+
     - name: add admin team
       run_once: true
       shell: >

--- a/common.yml
+++ b/common.yml
@@ -45,14 +45,13 @@
         mongo tsuru --eval "db.teams.update({_id: 'admin'}, {\$addToSet: {users: '{{admin_user}}'}})";
       delegate_to: "{{ mongodb_host }}"
 
-# TODO : handle the case where the user already exists
     - name: add admin user
       run_once: true
       uri:
         method=POST body_format=json
         body="{\"email\":\"{{ admin_user }}\",\"password\":\"{{ admin_password }}\"}"
         url=http://127.0.0.1:{{ api_port }}/users
-        status_code=201
+        status_code=201,409
 
     - name: login with the admin user
       run_once: true


### PR DESCRIPTION
#### Install python-httplib2 on API nodes

I'm planning to use Ansible's uri module which depends on this. If we make
more extensive use of this in the future then we should consider installing
it on all nodes.
#### Replace curl commands with Ansible uri module

These shell-outs and curl commands weren't registering an error when the
admin user wasn't created and/or it was unable to login. It would write an
empty `~/.tsuru_token` file and a later task which adds a docker node would
hang indefinitely because it triggered an interactive login.

Fix this by using Ansible's uri module which checks status codes and allows
us to parse the JSON response without piping it through another command.
#### Don't error if admin user already exists

The API will return `409 Conflict` if the user already exists. Allow this to
happen and for the subsequent tasks to continue.

---

Tested on AWS, new and existing.
