### PR TITLE
[#93438736] Add support for ssh over bastion hosts for GCE

### DIFF
--- a/gce.py
+++ b/gce.py
@@ -215,11 +215,12 @@ class GceInventory(object):
                 md[entry['key']] = entry['value']
 
         net = inst.extra['networkInterfaces'][0]['network'].split('/')[-1]
+
+        # Workaround for bug in gce.py fixes errors when no public IP present.
         if inst.public_ips.__len__() == 0:
           inst.public_ips=[None]
-          ansible_ssh_host=inst.private_ips[0]
-        else:
-          ansible_ssh_host=inst.public_ips[0]
+        # Use private IP for ssh access.
+        ansible_ssh_host=inst.private_ips[0]
 
         return {
             'gce_uuid': inst.uuid,


### PR DESCRIPTION
Ansible's `gce.py` dynamic inventory script defaults to using public
IP addresses but we use bastion hosts to connect and therefore we
need to use private IP addresses to prevent the following error:

```
fatal: [ci-tsuru-gandalf] => SSH Error: ssh: connect to host 104.155.72.198 port 22: Connection timed out
    while connecting to 104.155.72.198:22
It is sometimes useful to re-run the command using -vvvv, which prints SSH debug output to help diagnose the issue.
```

This enhances security as we only need ssh opened on a single host.

**What**

We have changed the default behaviour to output the hosts `private IP` as the `ansible_ssh_host` value rather than the hosts `public IP`

**Who should review this PR**
- Anyone on the core team,
- I paired with @jimconner on this one so he has to keep his mitts off the merge button
