### PR TITLE
Refactor Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: all \
 	aws gce \
-	check-env-var render-ssh-config \
+	preflight check-env-var render-ssh-config \
 	clean-roles ansible-galaxy \
 	import-gpg-keys recrypt
 
 all:
 	$(error Usage: make <aws|gce> DEPLOY_ENV=name [ARGS=extra_args])
 
-aws: check-env-var render-ssh-config
+aws: preflight
 ifndef AWS_SECRET_ACCESS_KEY
 	$(error Environment variable AWS_SECRET_ACCESS_KEY must be set)
 endif
@@ -16,8 +16,10 @@ ifndef AWS_ACCESS_KEY_ID
 endif
 	ansible-playbook -i ec2.py site-aws.yml -e "deploy_env=${DEPLOY_ENV}" -e "@platform-aws.yml" ${ARGS}
 
-gce: check-env-var render-ssh-config
+gce: preflight
 	SSL_CERT_FILE=$(shell python -m certifi) ansible-playbook -i gce.py site-gce.yml -e "deploy_env=${DEPLOY_ENV}" -e "@platform-gce.yml" ${ARGS}
+
+preflight: check-env-var render-ssh-config
 
 check-env-var:
 ifndef DEPLOY_ENV

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,20 @@
 	clean-roles ansible-galaxy \
 	import-gpg-keys recrypt
 
+ANSIBLE_PLAYBOOK_CMD = ansible-playbook \
+	-i $(1) \
+	site-$(2).yml \
+	-e "@platform-$(2).yml" \
+	-e "deploy_env=${DEPLOY_ENV}" ${ARGS}
+
 all:
 	$(error Usage: make <aws|gce> DEPLOY_ENV=name [ARGS=extra_args])
 
 aws: preflight check-env-aws
-	ansible-playbook -i ec2.py site-aws.yml -e "deploy_env=${DEPLOY_ENV}" -e "@platform-aws.yml" ${ARGS}
+	$(call ANSIBLE_PLAYBOOK_CMD,ec2.py,aws)
 
 gce: preflight
-	SSL_CERT_FILE=$(shell python -m certifi) ansible-playbook -i gce.py site-gce.yml -e "deploy_env=${DEPLOY_ENV}" -e "@platform-gce.yml" ${ARGS}
+	SSL_CERT_FILE=$(shell python -m certifi) $(call ANSIBLE_PLAYBOOK_CMD,gce.py,gce)
 
 preflight: check-env-var render-ssh-config
 

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,27 @@
 .PHONY: all \
 	aws gce \
-	preflight check-env-var render-ssh-config \
+	preflight check-env-var check-env-aws render-ssh-config \
 	clean-roles ansible-galaxy \
 	import-gpg-keys recrypt
 
 all:
 	$(error Usage: make <aws|gce> DEPLOY_ENV=name [ARGS=extra_args])
 
-aws: preflight
-ifndef AWS_SECRET_ACCESS_KEY
-	$(error Environment variable AWS_SECRET_ACCESS_KEY must be set)
-endif
-ifndef AWS_ACCESS_KEY_ID
-	$(error Environment variable AWS_ACCESS_KEY_ID must be set)
-endif
+aws: preflight check-env-aws
 	ansible-playbook -i ec2.py site-aws.yml -e "deploy_env=${DEPLOY_ENV}" -e "@platform-aws.yml" ${ARGS}
 
 gce: preflight
 	SSL_CERT_FILE=$(shell python -m certifi) ansible-playbook -i gce.py site-gce.yml -e "deploy_env=${DEPLOY_ENV}" -e "@platform-gce.yml" ${ARGS}
 
 preflight: check-env-var render-ssh-config
+
+check-env-aws:
+ifndef AWS_SECRET_ACCESS_KEY
+	$(error Environment variable AWS_SECRET_ACCESS_KEY must be set)
+endif
+ifndef AWS_ACCESS_KEY_ID
+	$(error Environment variable AWS_ACCESS_KEY_ID must be set)
+endif
 
 check-env-var:
 ifndef DEPLOY_ENV

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: all aws gce check-env-var render-ssh-config clean-roles ansible-galaxy import-gpg-keys recrypt
+.PHONY: all \
+	aws gce \
+	check-env-var render-ssh-config \
+	clean-roles ansible-galaxy \
+	import-gpg-keys recrypt
 
 all:
 	$(error Usage: make <aws|gce> DEPLOY_ENV=name [ARGS=extra_args])
@@ -30,8 +34,13 @@ ansible-galaxy:
 	ansible-galaxy install -r requirements.yml --force
 
 import-gpg-keys:
-	$(foreach var,$(shell cat gpg.recipients | awk -F: '{print $$1}'),gpg --list-public-key $(var) || gpg --keyserver hkp://keyserver.ubuntu.com --search-keys $(var);)
+	$(foreach var, \
+		$(shell cat gpg.recipients | awk -F: '{print $$1}'), \
+		gpg --list-public-key $(var) || gpg --keyserver hkp://keyserver.ubuntu.com --search-keys $(var); \
+	)
 
 recrypt: import-gpg-keys
-	ansible-vault decrypt group_vars/all/secure && pwgen -cynC1 15 | gpg --batch --yes --trust-model always -e -o vault_passphrase.gpg $(shell cat gpg.recipients | awk -F: {'printf "-r "$$1" "'}) && ansible-vault encrypt group_vars/all/secure
-
+	ansible-vault decrypt group_vars/all/secure && pwgen -cynC1 15 | \
+		gpg --batch --yes --trust-model always -e -o vault_passphrase.gpg \
+			$(shell cat gpg.recipients | awk -F: {'printf "-r "$$1" "'}) && \
+		ansible-vault encrypt group_vars/all/secure


### PR DESCRIPTION
No functional changes.

---
#### Makefile: Hard wrap long lines …

So that they're easier to read. The groupings in `.PHONY` are logical.
#### Makefile: Move common deps to "preflight" target …

So that it's easy to see what dependencies are common between aws/gce.
#### Makefile: break AWS check to separate target …

To match `check-env-var` and make the gce/aws targets look similar.
#### Makefile: move ansible-playbook command to macro …

So that we don't duplicate the argument structure between aws/gce.
