### PR TITLE
Remove unnecessary comments

### DIFF
--- a/site-aws.yml
+++ b/site-aws.yml
@@ -1,6 +1,5 @@
 ---
 
-# AWS-Specific variables and steps.
 - hosts: "{{ hosts_prefix }}-tsuru-registry*"
   sudo: yes
   vars:

--- a/site-gce.yml
+++ b/site-gce.yml
@@ -1,6 +1,5 @@
 ---
 
-# AWS-Specific variables and steps.
 - hosts: "{{ hosts_prefix }}-tsuru-registry"
   sudo: yes
   vars:


### PR DESCRIPTION
This is a good example of why comments should be used sparingly, if
at all; the comment in `site-gce.yml` was incorrect and has been for
as long as this file has existed. However, neither comment is
required, as the file names alone are clear enough indicators of
what the files are for.
