### PR TITLE
[#93688328] Update docker_server playbook to 0.0.2

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -12,7 +12,7 @@
 # GDS created and maintained playbooks
 - name: docker_server
   src: https://github.com/alphagov/ansible-playbook-docker_server.git
-  version: v0.0.1
+  version: v0.0.2
 - name: hipache
   src: https://github.com/alphagov/ansible-playbook-hipache.git
   version: v0.0.1


### PR DESCRIPTION
To pull in storage driver fix:

https://github.com/alphagov/ansible-playbook-docker_server/compare/v0.0.1...v0.0.2
