### PR TITLE
[#95964696] Update tsuru_api playbook to 0.0.2

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -18,7 +18,7 @@
   version: v0.0.1
 - name: tsuru_api
   src: https://github.com/alphagov/ansible-playbook-tsuru_api.git
-  version: v0.0.1
+  version: v0.0.2
 - name: gandalf
   src: https://github.com/alphagov/ansible-playbook-gandalf.git
   version: v0.0.1


### PR DESCRIPTION
To pull in fix for deprecated `docker:segregate` option:

https://github.com/alphagov/ansible-playbook-tsuru_api/compare/v0.0.1...v0.0.2
