### PR TITLE
[#95612064] Update hipache playbook to v0.0.2

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -15,7 +15,7 @@
   version: v0.0.2
 - name: hipache
   src: https://github.com/alphagov/ansible-playbook-hipache.git
-  version: v0.0.1
+  version: v0.0.2
 - name: tsuru_api
   src: https://github.com/alphagov/ansible-playbook-tsuru_api.git
   version: v0.0.2


### PR DESCRIPTION
This should have gone into ddf6e76cfb5c9be8f767515b7e18838825c1c4d2 because
a new version of the playbook is required to change Hipache's default port
from 80 to 8080.

https://github.com/alphagov/ansible-playbook-hipache/compare/v0.0.1...v0.0.2
