### PR TITLE
[#95697144] post install tasks

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -115,3 +115,4 @@
 
 - include: postgres.yml
 - include: router.yml
+- include: post-install.yml

--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -15,3 +15,6 @@ gandalf_host_internal: "{{ hostvars[groups[gandalf_host_name][0]][ip_field_name]
 
 mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
 mongodb_host: "{{ hostvars[groups[mongodb_host_name][0]][ip_field_name] }}"
+
+postgres_host_name: "{{ hosts_prefix }}-tsuru-postgres"
+postgres_host: "{{ hostvars[groups[postgres_host_name][0]][ip_field_name] }}"

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -15,3 +15,6 @@ gandalf_host_internal: "{{ hostvars[gandalf_host_name][ip_field_name] }}"
 
 mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
 mongodb_host: "{{ hostvars[mongodb_host_name][ip_field_name] }}"
+
+postgres_host_name: "{{ hosts_prefix }}-tsuru-postgres"
+postgres_host: "{{ hostvars[postgres_host_name][ip_field_name] }}"

--- a/post-install.yml
+++ b/post-install.yml
@@ -1,0 +1,158 @@
+- hosts: "{{ hosts_prefix }}-tsuru-api*[0]"
+  sudo: yes
+  tasks:
+    - name: Check tsuru_deployer key
+      stat: path=~/.ssh/tsuru_deployer
+      register: tsuru_deployer_key
+      delegate_to: "localhost"
+      sudo: no
+
+    - name: Generate tsuru_deployer key
+      shell: >
+        ssh-keygen -b 2048 -t rsa -f ~/.ssh/tsuru_deployer -q -N ""
+      when: tsuru_deployer_key.stat.exists == False
+      delegate_to: "localhost"
+      sudo: no
+    - name: Generate tsuru_deployer.pub key
+      shell: >
+        ssh-keygen -y -f ~/.ssh/tsuru_deployer >~/.ssh/tsuru_deployer.pub
+      when: tsuru_deployer_key.stat.exists == False
+      delegate_to: "localhost"
+      sudo: no
+
+    - name: Get localhost home
+      shell: >
+        echo ~
+      register: local_home
+      delegate_to: "localhost"
+      sudo: no
+    - name: Deploy tsuru_deployer.pub key
+      copy:
+        src: "{{ local_home.stdout }}/.ssh/tsuru_deployer.pub"
+        dest: ~/.ssh/
+        mode: 0600
+
+    - name: Tsuru pool-list
+      shell: > 
+        tsuru-admin pool-list
+      register: tsuru_pools
+    - name: Tsuru pool add default
+      shell: >
+        tsuru-admin pool-add default
+      when: "not 'default' in tsuru_pools.stdout"
+    - name: Check admin pool
+      shell: >
+        tsuru pool-list | grep admin
+      register: admin_pool
+    - name: Add admin team to default pool
+      shell: >
+        tsuru-admin pool-teams-add default admin
+      when: "not 'default' in admin_pool.stdout"
+
+    - name: Tsuru platform-list
+      shell: >
+        tsuru platform-list | awk {'print $2'}
+      register: tsuru_platforms
+    - name: Tsuru platform add python
+      ignore_errors: no
+      shell: >
+        tsuru-admin platform-add python -d https://raw.github.com/tsuru/basebuilder/master/python/Dockerfile
+      when: "not 'python' in tsuru_platforms.stdout"
+
+    - name: Tsuru key-list
+      shell: >
+        tsuru key-list
+      register: tsuru_keys
+    - name: Tsuru add ssh key
+      shell: >
+        tsuru key-add tsuru_deployer ~/.ssh/tsuru_deployer.pub
+      when: "not 'tsuru_deployer' in tsuru_keys.stdout"
+
+    - name: Tsuru app-list
+      shell: >
+        tsuru app-list
+      register: tsuru_apps
+    - name: Tsuru app-create dashboard
+      ignore_errors: yes
+      shell: >
+        tsuru app-create dashboard python
+      when: "not 'dashboard' in tsuru_apps.stdout"
+    - name: Get gandalf repo for dashboard
+      shell: >
+        tsuru app-info -a dashboard | grep -o 'git@.\+'
+      register: dashboard_git_remote
+
+# deploy from localhost (api server doesn't have firewall open to push to gandalf)
+    - name: Git pull dashboard
+      git:
+        repo: https://github.com/tsuru/tsuru-dashboard.git
+        dest: /tmp/tsuru-dashboard
+      delegate_to: "localhost"
+      sudo: no
+    - name: Git push dashboard to gandalf
+      shell: >
+        git push {{ dashboard_git_remote.stdout }} master
+      args: 
+        chdir: /tmp/tsuru-dashboard
+      delegate_to: "localhost"
+      sudo: no
+
+    - name: Tsuru app-info dashboard
+      shell: >
+        tsuru app-info -a dashboard
+      register: dashboard_app_info
+
+# This deploys postgresapi, but to fully operate more work needs to be done 
+# outside this repository (firewall configuration, ssl certificates etc.)
+    - name: Tsuru app-create postgresapi
+      ignore_errors: yes
+      shell: >
+        tsuru app-create postgresapi python
+      when: "not 'postgresapi' in tsuru_apps.stdout"
+    - name: Get gandalf repo for postgresapi
+      shell: >
+        tsuru app-info -a postgresapi | grep -o 'git@.\+'
+      register: postgresapi_git_remote
+
+    - name: Git pull postgresapi
+      git:
+        repo: https://github.com/tsuru/postgres-api
+        dest: /tmp/postgresapi
+      delegate_to: "localhost"
+      sudo: no
+    - name: Git push postgresapi to gandalf
+      shell: >
+        git push {{ postgresapi_git_remote.stdout }} master
+      args:
+        chdir: /tmp/postgresapi
+      register: postgresapi_push_result
+      delegate_to: "localhost"
+      sudo: no
+
+    - name: Tsuru app-info postgresapi
+      shell: >
+        tsuru app-info -a postgresapi
+      register: postgresapi_app_info
+
+    - name: Tsuru set environment variables for postgresapi
+      shell: >
+        tsuru env-set -a postgresapi POSTGRESAPI_DATABASE=postgresapi;
+        tsuru env-set -a postgresapi POSTGRESAPI_USER=postgresapi;
+        tsuru env-set -a postgresapi POSTGRESAPI_PASSWORD={{ pg_apiuser_pass }};
+        tsuru env-set -a postgresapi POSTGRESAPI_HOST={{ postgres_host }};
+        tsuru env-set -a postgresapi POSTGRESAPI_PORT=5432;
+        tsuru env-set -a postgresapi POSTGRESAPI_SALT=md5;
+        tsuru env-set -a postgresapi POSTGRESAPI_SHARED_HOST={{ postgres_host }};
+        tsuru env-set -a postgresapi POSTGRESAPI_SHARED_PORT=5432;
+        tsuru env-set -a postgresapi POSTGRESAPI_SHARED_ADMIN=postgresadmin;
+        tsuru env-set -a postgresapi POSTGRESAPI_SHARED_ADMIN_PASSWORD={{ pg_admin_pass }};
+        tsuru env-set -a postgresapi POSTGRESAPI_SHARED_PUBLIC_HOST={{ postgres_host }};
+      when: "not 'Everything up-to-date' in postgresapi_push_result.stderr"
+    - name: Tsuru app-run db upgrade
+      shell: >
+        tsuru app-run --app postgresapi -- python manage.py upgrade_db
+      when: "not 'Everything up-to-date' in postgresapi_push_result.stderr"
+
+    - debug: var=dashboard_app_info.stdout_lines
+    - debug: var=postgresapi_app_info.stdout_lines
+

--- a/post-install.yml
+++ b/post-install.yml
@@ -58,6 +58,16 @@
       shell: >
         tsuru-admin platform-add python -d https://raw.github.com/tsuru/basebuilder/master/python/Dockerfile
       when: "not 'python' in tsuru_platforms.stdout"
+    - name: Tsuru platform add java
+      ignore_errors: no
+      shell: >
+        tsuru-admin platform-add java -d https://raw.github.com/tsuru/basebuilder/master/java/Dockerfile
+      when: "not 'java' in tsuru_platforms.stdout"
+    - name: Tsuru platform add static
+      ignore_errors: no
+      shell: >
+        tsuru-admin platform-add static -d https://raw.github.com/tsuru/basebuilder/master/static/Dockerfile
+      when: "not 'static' in tsuru_platforms.stdout"
 
     - name: Tsuru key-list
       shell: >

--- a/post-install.yml
+++ b/post-install.yml
@@ -1,36 +1,34 @@
 - hosts: "{{ hosts_prefix }}-tsuru-api*[0]"
   sudo: yes
   tasks:
+    - name: Install git client
+      apt: name=git state=present
     - name: Check tsuru_deployer key
       stat: path=~/.ssh/tsuru_deployer
       register: tsuru_deployer_key
-      delegate_to: "localhost"
-      sudo: no
 
     - name: Generate tsuru_deployer key
       shell: >
         ssh-keygen -b 2048 -t rsa -f ~/.ssh/tsuru_deployer -q -N ""
       when: tsuru_deployer_key.stat.exists == False
-      delegate_to: "localhost"
-      sudo: no
     - name: Generate tsuru_deployer.pub key
       shell: >
         ssh-keygen -y -f ~/.ssh/tsuru_deployer >~/.ssh/tsuru_deployer.pub
       when: tsuru_deployer_key.stat.exists == False
-      delegate_to: "localhost"
-      sudo: no
 
-    - name: Get localhost home
-      shell: >
-        echo ~
-      register: local_home
-      delegate_to: "localhost"
-      sudo: no
-    - name: Deploy tsuru_deployer.pub key
+    - name: Generate ssh config for git
       copy:
-        src: "{{ local_home.stdout }}/.ssh/tsuru_deployer.pub"
-        dest: ~/.ssh/
+        content: |
+          Host {{ deploy_env }}-gandalf.{{ domain_name }}
+            HostName {{ deploy_env }}-gandalf.{{ domain_name }} 
+            User git
+            IdentityFile ~/.ssh/tsuru_deployer
+        dest: ~/.ssh/config        
         mode: 0600
+
+    - name: Add Gandalf to known hosts
+      shell: >
+        ssh-keyscan {{ deploy_env }}-gandalf.{{ domain_name }} >~/.ssh/known_hosts
 
     - name: Tsuru pool-list
       shell: > 
@@ -92,52 +90,44 @@
         tsuru app-info -a dashboard | grep -o 'git@.\+'
       register: dashboard_git_remote
 
-# deploy from localhost (api server doesn't have firewall open to push to gandalf)
     - name: Git pull dashboard
       git:
         repo: https://github.com/tsuru/tsuru-dashboard.git
         dest: /tmp/tsuru-dashboard
-      delegate_to: "localhost"
-      sudo: no
+
     - name: Git push dashboard to gandalf
       shell: >
         git push {{ dashboard_git_remote.stdout }} master
       args: 
         chdir: /tmp/tsuru-dashboard
-      delegate_to: "localhost"
-      sudo: no
 
     - name: Tsuru app-info dashboard
       shell: >
         tsuru app-info -a dashboard
       register: dashboard_app_info
 
-# This deploys postgresapi, but to fully operate more work needs to be done 
-# outside this repository (firewall configuration, ssl certificates etc.)
     - name: Tsuru app-create postgresapi
       ignore_errors: yes
       shell: >
         tsuru app-create postgresapi python
       when: "not 'postgresapi' in tsuru_apps.stdout"
-    - name: Get gandalf repo for postgresapi
-      shell: >
-        tsuru app-info -a postgresapi | grep -o 'git@.\+'
-      register: postgresapi_git_remote
 
     - name: Git pull postgresapi
       git:
         repo: https://github.com/tsuru/postgres-api
         dest: /tmp/postgresapi
-      delegate_to: "localhost"
-      sudo: no
+
+    - name: Get gandalf repo for postgresapi
+      shell: >
+        tsuru app-info -a postgresapi | grep -o 'git@.\+'
+      register: postgresapi_git_remote
+
     - name: Git push postgresapi to gandalf
       shell: >
         git push {{ postgresapi_git_remote.stdout }} master
       args:
         chdir: /tmp/postgresapi
       register: postgresapi_push_result
-      delegate_to: "localhost"
-      sudo: no
 
     - name: Tsuru app-info postgresapi
       shell: >


### PR DESCRIPTION
- specify pool name when registering docker node (fixes tsuru 0.11.1 behaviour where nodes are not added to any pool by default)
- configure default pools
- add insecure_deployer key for git
- install python, java and static platforms
- deploy dashboard
- deploy postgresapi
- configure postgresapi
- display app info in the end of run

All tsuru operations are run on tsuru-api*[0] server so that GCE and AWS jobs can run concurrently. Code of dashboard and postgresapi is pushed from localhost.
