### PR TITLE
[#94300924] Add docker node metadata for Tsuru 0.11.1

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -88,14 +88,30 @@
   post_tasks:
     - name: Register node.
       shell: >
-        tsuru-admin docker-node-add --register address=http://{{ gce_private_ip }}:{{ docker_port }}
+        tsuru-admin docker-node-add --register address=http://{{ gce_private_ip }}:{{ docker_port }} pool=default
       delegate_to: "{{ tsuru_api_host }}"
       when: gce_private_ip is defined
     - name: Register node.
       shell: >
-        tsuru-admin docker-node-add --register address=http://{{ ec2_private_ip_address }}:{{ docker_port }}
+        tsuru-admin docker-node-add --register address=http://{{ ec2_private_ip_address }}:{{ docker_port }} pool=default
       delegate_to: "{{ tsuru_api_host }}"
       when: ec2_private_ip_address is defined
+    - name: Check docker nodes are in the default pool
+      shell: >
+        tsuru-admin docker-node-list -f pool=default
+      delegate_to: "{{ tsuru_api_host }}"
+      register: docker_node_list
+    - name: Update docker node metadata for default pool (AWS)
+      shell: >
+        tsuru-admin docker-node-update http://{{ ec2_private_ip_address }}:{{ docker_port }} pool=default
+      delegate_to: "{{ tsuru_api_host }}"
+      when: "ec2_private_ip_address is defined and not ec2_private_ip_address in docker_node_list.stdout"
+    - name: Update docker node metadata for default pool (GCE)
+      shell: >
+        tsuru-admin docker-node-update http://{{ gce_private_ip }}:{{ docker_port }} pool=default
+      delegate_to: "{{ tsuru_api_host }}"
+      when: "gce_private_ip is defined and not gce_private_ip in docker_node_list.stdout"
+
 
 - include: postgres.yml
 - include: router.yml


### PR DESCRIPTION
Tsuru 0.11.1 adds the requirement that we set pools using the node metadata.

This commit sets the pool=default for any new deployments and also checks and
updates the metadata for any existing deployments.

This PR has been raised separately from the post-install task as we could do with this one merged regardless of the post-install PR.
