### PR TITLE
[#93541780] Nginx SSL reverse proxy in front of API

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -16,50 +16,7 @@
   roles:
     - gandalf
 
-- hosts: "{{ hosts_prefix }}-tsuru-api*"
-  sudo: yes
-  roles:
-    - role: tsuru_api
-      tags: tsuru_api
-
-- hosts: "{{ hosts_prefix }}-tsuru-api*"
-  sudo: yes
-  tasks:
-    - name: Install httplib2 for Ansible uri module
-      apt: name=python-httplib2 state=present
-
-    - name: add admin team
-      run_once: true
-      shell: >
-        mongo tsuru --eval 'db.teams.update({_id: "admin"}, {_id: "admin"}, {upsert: true})';
-      delegate_to: "{{ mongodb_host }}"
-
-    - name: add admin user to admin team
-      run_once: true
-      shell: >
-        mongo tsuru --eval "db.teams.update({_id: 'admin'}, {\$addToSet: {users: '{{admin_user}}'}})";
-      delegate_to: "{{ mongodb_host }}"
-
-    - name: add admin user
-      run_once: true
-      uri:
-        method=POST body_format=json
-        body="{\"email\":\"{{ admin_user }}\",\"password\":\"{{ admin_password }}\"}"
-        url=http://127.0.0.1:{{ api_port }}/users
-        status_code=201,409
-
-    - name: login with the admin user
-      run_once: true
-      uri:
-        method=POST body_format=json
-        body="{\"password\":\"{{ admin_password }}\"}"
-        url=http://127.0.0.1:{{ api_port }}/users/{{ admin_user }}/tokens
-        return_content=yes
-      register: login_response
-
-    - name: write admin token
-      run_once: true
-      copy: dest=~/.tsuru_token mode=0600 content="{{ (login_response.content|from_json).token }}"
+- include: tsuru_api.yml
 
 - hosts: "{{ hosts_prefix }}-tsuru-gandalf*"
   sudo: yes

--- a/router.yml
+++ b/router.yml
@@ -1,43 +1,15 @@
 - hosts: "{{ hosts_prefix }}-tsuru-router*"
   sudo: yes
-  pre_tasks:
-   - name: Update APT cache
-     apt: >
-        update_cache=yes
-   - name: Create Nginx Directory
-     file: dest=/etc/nginx mode=755 owner=root group=root state=directory
-   - name: Upload Unencrypted Key File
-     copy: content="{{ ssl_key }}" dest=/etc/nginx/wildcard.tsuru.paas.alphagov.co.uk.key owner=root group=root
-   - name: Upload Unencrypted Cert File
-     copy: content="{{ ssl_crt }}" dest=/etc/nginx/wildcard.tsuru.paas.alphagov.co.uk.site.chain.crt owner=root group=root
   vars:
     hipache_port: 8080
+    upstream_port: "{{ api_port }}"
+  vars_files:
+    - "ssl_proxy_vars.yml"
+  pre_tasks:
+    - include: ssl_proxy_pre.yml
   roles:
     - role: hipache
       hipache_listen_port: "{{ hipache_port }}"
       hipache_listen_address: '127.0.0.1'
       hipache_listen_address6: '::1'
     - role: jdauphant.nginx
-      nginx_sites:
-        ssl_reverse_proxy:
-          - listen 443 ssl
-          - ssl_certificate wildcard.tsuru.paas.alphagov.co.uk.site.chain.crt
-          - ssl_certificate_key wildcard.tsuru.paas.alphagov.co.uk.key
-          - server_name tsuru.paas.alphagov.co.uk
-          - location / {
-            proxy_pass http://localhost:{{ hipache_port }}/;
-            proxy_redirect default;
-            proxy_redirect http://$host/ https://$host/;
-            proxy_redirect http://$hostname/ https://$host/;
-            proxy_read_timeout 15s;
-            proxy_connect_timeout 15s;
-            }
-        default:
-          - listen 80
-          - return 301 https://$host$request_uri
-      nginx_configs:
-        proxy:
-          - proxy_set_header Host $http_host
-          - proxy_set_header X-Real-IP  $remote_addr
-          - proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
-          - proxy_set_header X-Forwarded-Proto https

--- a/ssl_proxy_pre.yml
+++ b/ssl_proxy_pre.yml
@@ -1,0 +1,10 @@
+---
+- name: Update APT cache
+  apt: >
+    update_cache=yes
+- name: Create Nginx Directory
+  file: dest=/etc/nginx mode=755 owner=root group=root state=directory
+- name: Upload Unencrypted Key File
+  copy: content="{{ ssl_key }}" dest=/etc/nginx/wildcard.tsuru.paas.alphagov.co.uk.key owner=root group=root
+- name: Upload Unencrypted Cert File
+  copy: content="{{ ssl_crt }}" dest=/etc/nginx/wildcard.tsuru.paas.alphagov.co.uk.site.chain.crt owner=root group=root

--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -4,7 +4,7 @@ nginx_sites:
     - listen 443 ssl
     - ssl_certificate wildcard.tsuru.paas.alphagov.co.uk.site.chain.crt
     - ssl_certificate_key wildcard.tsuru.paas.alphagov.co.uk.key
-    - server_name tsuru.paas.alphagov.co.uk
+    - server_name {{ domain_name }}
     - location / {
       proxy_pass http://localhost:{{ upstream_port }}/;
       proxy_redirect default;

--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -1,0 +1,24 @@
+---
+nginx_sites:
+  ssl_reverse_proxy:
+    - listen 443 ssl
+    - ssl_certificate wildcard.tsuru.paas.alphagov.co.uk.site.chain.crt
+    - ssl_certificate_key wildcard.tsuru.paas.alphagov.co.uk.key
+    - server_name tsuru.paas.alphagov.co.uk
+    - location / {
+      proxy_pass http://localhost:{{ upstream_port }}/;
+      proxy_redirect default;
+      proxy_redirect http://$host/ https://$host/;
+      proxy_redirect http://$hostname/ https://$host/;
+      proxy_read_timeout 15s;
+      proxy_connect_timeout 15s;
+      }
+  default:
+    - listen 80
+    - return 301 https://$host$request_uri
+nginx_configs:
+  proxy:
+    - proxy_set_header Host $http_host
+    - proxy_set_header X-Real-IP  $remote_addr
+    - proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+    - proxy_set_header X-Forwarded-Proto https

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -3,9 +3,6 @@
   roles:
     - role: tsuru_api
       tags: tsuru_api
-
-- hosts: "{{ hosts_prefix }}-tsuru-api*"
-  sudo: yes
   tasks:
     - name: Install httplib2 for Ansible uri module
       apt: name=python-httplib2 state=present

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -1,0 +1,44 @@
+- hosts: "{{ hosts_prefix }}-tsuru-api*"
+  sudo: yes
+  roles:
+    - role: tsuru_api
+      tags: tsuru_api
+
+- hosts: "{{ hosts_prefix }}-tsuru-api*"
+  sudo: yes
+  tasks:
+    - name: Install httplib2 for Ansible uri module
+      apt: name=python-httplib2 state=present
+
+    - name: add admin team
+      run_once: true
+      shell: >
+        mongo tsuru --eval 'db.teams.update({_id: "admin"}, {_id: "admin"}, {upsert: true})';
+      delegate_to: "{{ mongodb_host }}"
+
+    - name: add admin user to admin team
+      run_once: true
+      shell: >
+        mongo tsuru --eval "db.teams.update({_id: 'admin'}, {\$addToSet: {users: '{{admin_user}}'}})";
+      delegate_to: "{{ mongodb_host }}"
+
+    - name: add admin user
+      run_once: true
+      uri:
+        method=POST body_format=json
+        body="{\"email\":\"{{ admin_user }}\",\"password\":\"{{ admin_password }}\"}"
+        url=http://127.0.0.1:{{ api_port }}/users
+        status_code=201,409
+
+    - name: login with the admin user
+      run_once: true
+      uri:
+        method=POST body_format=json
+        body="{\"password\":\"{{ admin_password }}\"}"
+        url=http://127.0.0.1:{{ api_port }}/users/{{ admin_user }}/tokens
+        return_content=yes
+      register: login_response
+
+    - name: write admin token
+      run_once: true
+      copy: dest=~/.tsuru_token mode=0600 content="{{ (login_response.content|from_json).token }}"

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -1,8 +1,15 @@
 - hosts: "{{ hosts_prefix }}-tsuru-api*"
   sudo: yes
+  pre_tasks:
+    - include: ssl_proxy_pre.yml
+  vars:
+    upstream_port: "{{ api_port }}"
+  vars_files:
+    - "ssl_proxy_vars.yml"
   roles:
     - role: tsuru_api
       tags: tsuru_api
+    - role: jdauphant.nginx
   tasks:
     - name: Install httplib2 for Ansible uri module
       apt: name=python-httplib2 state=present


### PR DESCRIPTION
So that we can secure access to the API on all providers.

We don't currently have SSL on the API in GCE environments because the load
balancers which do SSL termination aren't currently supported by Terraform.
We do have ELBs terminating SSL in AWS, but the certificate upload process
is outside of Terraform.

This won't currently be used. I'm going to roll this out in several steps
because we don't currently have an SSL certificate for GCE and the Tsuru
client won't work on cert validation errors. These steps will follow:
- change the AWS load balancer to forward to TCP:443 instead of terminating
  SSL (but retain HTTP:8080 forwarding for the moment)
- add TCP:443 forwarding to the GCE load balancer

Then when we have the GCE certificate deployed to the right machines:
- remove all HTTP:8080 listeners and forwarders on load balancers
- change the API to only listen on `127.0.0.1:8080`

I was originally hoping to implement this using Tsuru's `use-tls` option
which allows you to pass a certificate and key for Tsuru to do SSL
termination. However this would have made the local `tsuru` and
`tsuru-admin` commands fail, which hit the API over loopback to do things
like register Docker nodes, due to SSL certificate hostname validation.

That could have been overcome by calling out to the internal load balancer
but that would have required waiting for enough health checks to pass for
the instances to be brought into service and it all seemed like unnecessary
complexity.
