### PR TITLE
[#93705168] Configure docker registry to use gcs bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,7 @@ root directory of this repo. The contents are as follows:
 ```
 GCE_PARAMS = ('...@developer.gserviceaccount.com', '/path/to/gce_account.json')
 GCE_KEYWORD_PARAMS = {'project': 'project_id'}
-GCS_ACCESS_KEY=<your gcs access key>
-GCS_SECRET_KEY=<your gcs secret key>
 ```
-
-Instructions on how to get your `GCS_ACCESS_KEY` and `GCS_SECRET_KEY` can be found [here](https://developers.google.com/storage/docs/reference/v1/getting-startedv1#keys)
 
 
 * [GnuPG](#setting-up-gpg-encrypted-vault-password-support)
@@ -116,6 +112,15 @@ max-cache-ttl 172800
 ##### Final step
 
 Start a new shell or source your bashrc i.e. `. ~/.bashrc`
+
+### Docker registry on the Google Platform
+
+We use a service account with [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).
+
+[We have scoped the access](https://github.com/alphagov/tsuru-terraform/pull/62) of the service account access token to `storage-rw` to allow docker registry read-write access to the `gcs` bucket, this allows:
+
+* The docker registry to get its authorization credentials by making api calls to google
+* The team to provision docker registries with out having to setup their own gcs access and secret keys
 
 ### Instructions:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ root directory of this repo. The contents are as follows:
 ```
 GCE_PARAMS = ('...@developer.gserviceaccount.com', '/path/to/gce_account.json')
 GCE_KEYWORD_PARAMS = {'project': 'project_id'}
+GCS_ACCESS_KEY=<your gcs access key>
+GCS_SECRET_KEY=<your gcs secret key>
 ```
+
+Instructions on how to get your `GCS_ACCESS_KEY` and `GCS_SECRET_KEY` can be found [here](https://developers.google.com/storage/docs/reference/v1/getting-startedv1#keys)
+
 
 * [GnuPG](#setting-up-gpg-encrypted-vault-password-support)
 

--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -15,3 +15,6 @@ gandalf_port: 8080
 
 mongodb_conf_bind_ip: 0.0.0.0
 mongodb_port: 27017
+
+google_cloud_storage_access_key: "{{ lookup('env', 'GCS_ACCESS_KEY') }}"
+google_cloud_storage_secret_key: "{{ lookup('env', 'GCS_SECRET_KEY') }}"

--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -15,6 +15,3 @@ gandalf_port: 8080
 
 mongodb_conf_bind_ip: 0.0.0.0
 mongodb_port: 27017
-
-google_cloud_storage_access_key: "{{ lookup('env', 'GCS_ACCESS_KEY') }}"
-google_cloud_storage_secret_key: "{{ lookup('env', 'GCS_SECRET_KEY') }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 # vim:ft=ansible:
 
 - src: aalda.docker-registry
-  version: v1.0.4
+  version: v1.0.5
 - src: jdauphant.nginx
   version: v1.3.4
 - src: ANXS.postgresql

--- a/site-gce.yml
+++ b/site-gce.yml
@@ -12,9 +12,7 @@
     storage_type: "gcs"
     gcs_bucket: "{{ deploy_env }}-mcp-registry-storage"
     gcs_storage_path: "/"
-    gcs_oauth2: false
-    gcs_access_key: "{{ google_cloud_storage_access_key }}"
-    gcs_secret_key: "{{ google_cloud_storage_secret_key }}"
+    use_gcs_default_credentials: true
   roles:
     - aalda.docker-registry
 

--- a/site-gce.yml
+++ b/site-gce.yml
@@ -9,13 +9,12 @@
     use_redis: false
     registry_ssl: false
 
-    # Settings below for when we enable gcs backend
-    # storage_type: "gcs"
-    #gcs_bucket: "{{ deploy_env }}.registry.storage"
-    #gcs_storage_path: "/"
-    #gcs_oauth2: false
-    #gcs_access_key: "{{ lookup('env', 'GCS_ACCESS_KEY') }}"
-    #gcs_secret_key: "{{ lookup('env', 'GCS_SECRET_KEY') }}"
+    storage_type: "gcs"
+    gcs_bucket: "{{ deploy_env }}-mcp-registry-storage"
+    gcs_storage_path: "/"
+    gcs_oauth2: false
+    gcs_access_key: "{{ google_cloud_storage_access_key }}"
+    gcs_secret_key: "{{ google_cloud_storage_secret_key }}"
   roles:
     - aalda.docker-registry
 


### PR DESCRIPTION
[Registry uses GCS on GCE](https://www.pivotaltracker.com/story/show/93705168)

**What**

**Acceptance Criteria**
**Given:** that I am deploying the platform to GCE
**When:** I run the provisioning and orchestration scripts
**Then:** the resulting platform has the Registry data stored on resilient storage outside the container
**When:** the Registry instance fails and a new Registry instance is created
**Then:** the new Registry instance is able to read the data on the resilient data store.

**How this PR should be reviewed**

I've created this PR to be reviewed in the following context:
- I want to configure the registry to use a `gcs` bucket with interoperability keys,
- I want to show people how to configure their own environments,
- I have been made aware that the use of interoperability keys requires additional work for people to do which may not be appreciated, i.e. generating and managing your own keys,
- I need to pull in an updated playbook from upstream that will use service account based authorisation to share `gcs` bucket credentials across the entire team,
- I need to migrate my docker registry's `gcs` bucket authentication and authorisation method from interoperability keys to service account based authorisation,
- I need to update the documentation to show we have changed from interoperability keys to service account based authorisation.

**Who should review this PR**
- Any one on the main team with the exception of @dhilton, @keymon, Colin Saliceti since they paired with me on this one. :p
