### PR TITLE
Run ansible-galaxy only when necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 secrets.py*
 roles
 ssh.config
+.ansible-galaxy.check

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,10 @@ render-ssh-config: check-env-var
 clean-roles:
 	rm -rf -- roles/*
 
-ansible-galaxy:
+ansible-galaxy: .ansible-galaxy.check
+.ansible-galaxy.check: requirements.yml
 	ansible-galaxy install -r requirements.yml --force
+	touch .ansible-galaxy.check
 
 import-gpg-keys:
 	$(foreach var, \


### PR DESCRIPTION
Currently we run the ansible-galaxy every time we run make,
even when it is not required if `requirements.yml` did not
change.

In this commit using a file as a flag to keep track of the
last run of `ansible-galaxy` task. `ansible-galaxy` will only
run if the task never run or `requirements.yml` is newer.

@annashipman originally added the this task.
