### PR TITLE
De-dupe docker-node-* tasks for AWS and GCE

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -88,30 +88,18 @@
   post_tasks:
     - name: Register node.
       shell: >
-        tsuru-admin docker-node-add --register address=http://{{ gce_private_ip }}:{{ docker_port }} pool=default
+        tsuru-admin docker-node-add --register address=http://{{ ansible_default_ipv4.address }}:{{ docker_port }} pool=default
       delegate_to: "{{ tsuru_api_host }}"
-      when: gce_private_ip is defined
-    - name: Register node.
-      shell: >
-        tsuru-admin docker-node-add --register address=http://{{ ec2_private_ip_address }}:{{ docker_port }} pool=default
-      delegate_to: "{{ tsuru_api_host }}"
-      when: ec2_private_ip_address is defined
     - name: Check docker nodes are in the default pool
       shell: >
         tsuru-admin docker-node-list -f pool=default
       delegate_to: "{{ tsuru_api_host }}"
       register: docker_node_list
-    - name: Update docker node metadata for default pool (AWS)
+    - name: Update docker node metadata for default pool
       shell: >
-        tsuru-admin docker-node-update http://{{ ec2_private_ip_address }}:{{ docker_port }} pool=default
+        tsuru-admin docker-node-update http://{{ ansible_default_ipv4.address }}:{{ docker_port }} pool=default
       delegate_to: "{{ tsuru_api_host }}"
-      when: "ec2_private_ip_address is defined and not ec2_private_ip_address in docker_node_list.stdout"
-    - name: Update docker node metadata for default pool (GCE)
-      shell: >
-        tsuru-admin docker-node-update http://{{ gce_private_ip }}:{{ docker_port }} pool=default
-      delegate_to: "{{ tsuru_api_host }}"
-      when: "gce_private_ip is defined and not gce_private_ip in docker_node_list.stdout"
-
+      when: "not ansible_default_ipv4.address in docker_node_list.stdout"
 
 - include: postgres.yml
 - include: router.yml


### PR DESCRIPTION
By getting the hosts private IP address from Ansible's default variables
(facts?) instead of the dynamic inventory. This has the same effect, but is
much simpler and means that we don't have to maintain the same commands in
two places.
