### PR TITLE
Use ssh.config when connecting to the nat host

### DIFF
--- a/ssh.config.template
+++ b/ssh.config.template
@@ -12,7 +12,7 @@ Host DEPLOY_ENV-nat.tsuru.paas.alphagov.co.uk
 Host 10.128.*.*
     ServerAliveInterval    60
     TCPKeepAlive           yes
-    ProxyCommand           ssh -q -A ec2-user@DEPLOY_ENV-nat.tsuru.paas.alphagov.co.uk nc %h %p
+    ProxyCommand           ssh -F ssh.config -q -A ec2-user@DEPLOY_ENV-nat.tsuru.paas.alphagov.co.uk nc %h %p
     ControlMaster          auto
     ControlPath            ~/.ssh/mux-%r@%h:%p
     ControlPersist         8h
@@ -32,7 +32,7 @@ Host DEPLOY_ENV-nat.tsuru2.paas.alphagov.co.uk
 Host 10.129.*.*
     ServerAliveInterval    60
     TCPKeepAlive           yes
-    ProxyCommand           ssh -q -A ubuntu@DEPLOY_ENV-nat.tsuru2.paas.alphagov.co.uk nc %h %p
+    ProxyCommand           ssh -F ssh.config -q -A ubuntu@DEPLOY_ENV-nat.tsuru2.paas.alphagov.co.uk nc %h %p
     ControlMaster          auto
     ControlPath            ~/.ssh/mux-%r@%h:%p
     ControlPersist         8h


### PR DESCRIPTION
We use a custom `ssh.config` file to connect to our VM instances via
a bastion ssh host (nat). Ansible refers to this ssh.config file for
all instances.

But the private instances use the `ProxyCommand` and spawn a separated
ssh command, but in this case we don't pass the option `-F ssh.config`.

For consistency and to ensure that the config can run in any system,
we should add this option.
