### PR TITLE
[#91208752] Enable ssl support for postgres

### DIFF
--- a/postgres.yml
+++ b/postgres.yml
@@ -10,6 +10,7 @@
     postgresql_version: 9.3
     postgresql_encoding: 'UTF-8'
     postgresql_locale: 'en_US.UTF-8'
+    postgresql_ssl : true
 
     postgresql_pg_hba_default:
       - { type: host,  database: all, user: all, address: '0.0.0.0/0',    method: '{{ postgresql_default_auth_method }}', comment: 'Allow all IPv4 remote connections:' }


### PR DESCRIPTION
**What**

We wish communication between applications and database to be encrypted to prevent wire-sniffing attacks. This requires that ssl support is switched on in postgres
- set the `postgresql_ssl flag` to `true` to enable `ssl = on` to be renedered in the postgres.conf template.

Client applications will automatically detect that SSL support is enabled on the postgres server and will automatically upgrade their connections to use SSL for communications between app and database.

**How to review this PR**

I've created the PR to be reviewed in the following context:
- I need an application to communicate securely with it's databse

**Who should review this PR**
- Anyone in the core team.
