### PR TITLE
[#95695338] Shutdown insecure tsuru

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -14,7 +14,8 @@
 - hosts: "{{ hosts_prefix }}-tsuru-gandalf*"
   sudo: yes
   roles:
-    - gandalf
+    - role: gandalf
+      tsuru_api_endpoint: "{{ tsuru_api_internal_url }}"
 
 - include: tsuru_api.yml
 

--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -15,3 +15,6 @@ gandalf_port: 8080
 
 mongodb_conf_bind_ip: 0.0.0.0
 mongodb_port: 27017
+
+tsuru_api_external_url: https://{{ tsuru_api_external_lb }}:443
+tsuru_api_internal_url: https://{{ tsuru_api_internal_lb }}:443

--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -11,6 +11,7 @@ redis_host: "{{ hostvars[groups[redis_host_name][0]][ip_field_name] }}"
 tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api"
 tsuru_api_host: "{{ hostvars[groups[tsuru_api_host_name][0]][ip_field_name] }}"
 tsuru_api_internal_lb: "{{ deploy_env }}-api-int.{{ domain_name }}"
+tsuru_api_external_lb: "{{ deploy_env }}-api.{{ domain_name }}"
 
 gandalf_host_name: "{{ hosts_prefix }}-tsuru-gandalf"
 gandalf_host_internal: "{{ hostvars[groups[gandalf_host_name][0]][ip_field_name] }}"

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -11,6 +11,7 @@ redis_host: "{{ hostvars[redis_host_name][ip_field_name] }}"
 tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api-0"
 tsuru_api_host: "{{ hostvars[tsuru_api_host_name][ip_field_name] }}"
 tsuru_api_internal_lb: "{{ hosts_prefix }}-api.{{ domain_name }}"
+tsuru_api_external_lb: "{{ hosts_prefix }}-api.{{ domain_name }}"
 
 gandalf_host_name: "{{ hosts_prefix }}-tsuru-gandalf"
 gandalf_host_internal: "{{ hostvars[gandalf_host_name][ip_field_name] }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -18,10 +18,10 @@
   version: v0.0.2
 - name: tsuru_api
   src: https://github.com/alphagov/ansible-playbook-tsuru_api.git
-  version: v0.0.2
+  version: v0.0.3
 - name: gandalf
   src: https://github.com/alphagov/ansible-playbook-gandalf.git
-  version: v0.0.1
+  version: v0.0.2
 
 # GDS Forked, pull-request sent upstream awaiting merge.
 - name: bennojoy.redis

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -3,7 +3,9 @@
   pre_tasks:
     - include: ssl_proxy_pre.yml
   vars:
+    tsuru_api_listen_addr: 127.0.0.1
     upstream_port: "{{ api_port }}"
+    tsuru_api_url: "{{ tsuru_api_external_url }}"
   vars_files:
     - "ssl_proxy_vars.yml"
   roles:


### PR DESCRIPTION
**What**

[#95695338 Shutdown insecure tsuru](https://www.pivotaltracker.com/n/projects/1275640/stories/95695338)

We remove the dependencies on the insecure plain HTTP api traffic on port 8080, before shutting down the LB routing in the terraform configuration. 

**How this PR should be reviewed** 

We've created this PR to be reviewed in the following context:
- We want to make tsuru API listen only on 127.0.0.1:8080, so it cannot be accessed from outside the server but only via the nginx SSL termination on port 443. 
- We want all the internal tsuru services connect via `HTTPS/443`  (Note: Currently only `gandalf` needs to be changed).

For this, we need to use new releases of these roles:
- `tsuru-api v0.0.3`  to [allow change listen parameters](https://github.com/alphagov/ansible-playbook-tsuru_api/pull/4)
- `gandalf v.0.0.2` to [allow change the remote tsuru API endpoint](https://github.com/alphagov/ansible-playbook-gandalf/pull/2)

Global variables to refer the `tsuru_api` internal and external LB and URL are also added.

**Who should review this PR**

Any one on the main team with the exception of @actionjack and @keymon

**Dependencies** 

This PR should be merged before the related one which deletes the HTTPS/8080 LB routing in `tsuru-terraform`, to avoid break the state.
