### PR TITLE
Make target to diff vault contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ secrets.py*
 roles
 ssh.config
 .ansible-galaxy.check
+.diff-vault.fifo


### PR DESCRIPTION
Add a new make target to diff the contents of the vault against the master
branch. This is useful when reviewing pull requests, because the vault
contents are binary/encrypted.

Some notes about the implementation:
- this should be run from the branch you're reviewing
- `git show` is used to fetch the contents of the vault from the `master`
  branch
- the contents are redirected to a FIFO so that `ansible-vault` has
  something that looks like a file (it doesn't take STDIN)
- the contents are encrypted and don't actually touch the disk, so it's
  pretty safe
- the redirect blocks until the FIFO has been read by `ansible-vault` and
  then the `rm` deletes the FIFO, which is why the subshell is backgrounded
- bash is required to to do the `<(command)` process substitution because
  the default of `/bin/sh` doesn't support it
- we ignore an exit code of `1` because that indicates that there are
  differences rather than an error

---

I think this is portable, but it's worth someone testing it on Linux.
