### PR TITLE
[#96173596]Workaround for multichannel ssh issue

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -39,6 +39,7 @@
       service: name=gandalf-server state=restarted
 
 - hosts: "{{ hosts_prefix }}-tsuru-docker*"
+  serial: 1
   sudo: yes
   roles:
     - docker_server


### PR DESCRIPTION
[Add second docker app node](https://www.pivotaltracker.com/story/show/96173596)

**What**

Workaround for multichannel ssh terminating abruptly during the ansible
run on the docker server nodes. The issue manifests on `AWS` and there
is an open issue on [launchpad](https://bugs.launchpad.net/ubuntu/+source/openssh/+bug/1334916) for it.

The error I get from ansible is:

```
fatal: [10.128.13.93 -> 10.128.11.225] => SSH Error: Shared connection to 10.128.11.225 closed.
It is sometimes useful to re-run the command using -vvvv, which prints SSH debug output to help diagnose the issue.
fatal: [10.128.11.252 -> 10.128.11.225] => SSH Error: Shared connection to 10.128.11.225 closed.
It is sometimes useful to re-run the command using -vvvv, which prints SSH debug output to help diagnose the issue.

FATAL: all hosts have already failed -- aborting
```

In the tsuru-api server's auth.log file I can see the following errors:

```
Jun 15 14:22:31 ip-10-128-11-225 sshd[7885]: fatal: mm_request_receive_expect: read: rtype 29 != type
 157
Jun 15 14:22:31 ip-10-128-11-225 sshd[7356]: error: buffer_get_ret: trying to get more bytes 1 than i
n buffer 0
Jun 15 14:22:31 ip-10-128-11-225 sshd[7356]: error: buffer_get_char_ret: buffer_get_ret failed
Jun 15 14:22:31 ip-10-128-11-225 sshd[7356]: fatal: buffer_get_char: buffer error
Jun 15 14:22:31 ip-10-128-11-225 sshd[7303]: fatal: mm_request_receive: read: Connection reset by pee
r
Jun 15 14:22:31 ip-10-128-11-225 sshd[7303]: pam_unix(sshd:session): session closed for user ubuntu
```

The workaround is to run ansible serially (i.e. one node after another)
rather than in parallel.

**How to test**
- Provision an environment within `AWS` using the [tsuru-terraform second docker node branch](https://github.com/alphagov/tsuru-terraform/pull/72)
- Run `tsuru-ansible` master branch against the provisioned environment at least twice and observe failure when attempting to configure the `docker server` nodes
- Run `tsuru-ansible` `96173596_add_second_docker_node` branch against the provisioned environment
