### PR TITLE
[#91513820] Pull in updated tsuru-api playbook

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -18,7 +18,7 @@
   version: v0.0.2
 - name: tsuru_api
   src: https://github.com/alphagov/ansible-playbook-tsuru_api.git
-  version: v0.0.3
+  version: v0.0.4
 - name: gandalf
   src: https://github.com/alphagov/ansible-playbook-gandalf.git
   version: v0.0.2


### PR DESCRIPTION
[Application healing](https://www.pivotaltracker.com/story/show/91513820)

**What**

In order to make `Tsuru` autoheal we need to add two new settings:
- `healing_active_monitoring_interval` - Number of seconds between calls
  to `<server>/_ping` in each one of the docker nodes,
  [for more information check
  here](http://tsuru.readthedocs.org/en/stable/reference/config.html?highlight=unit#docker-healing-active-monitoring-interval)
- `healing_heal_containers_timeout` - Number of seconds a container
  should be unresponsive before triggering the recreation of the
  container, [for more information check
  here](http://tsuru.readthedocs.org/en/stable/reference/config.html?highlight=unit#docker-healing-heal-containers-timeout)

v0.0.4 of the [ansible-playbook-tsuru-api](https://github.com/alphagov/ansible-playbook-tsuru_api/pull/5)
adds support for the settings above.

**Who should review this PR**
- Anyone on the core team with the exception of @saliceti who I paired with :p
