### PR TITLE
[#97198688] API SSL proxy disable buffering, increase read timeout

### DIFF
--- a/api_ssl_proxy_vars.yml
+++ b/api_ssl_proxy_vars.yml
@@ -1,0 +1,25 @@
+---
+nginx_sites:
+  ssl_reverse_proxy:
+    - listen 443 ssl
+    - ssl_certificate wildcard.tsuru.paas.alphagov.co.uk.site.chain.crt
+    - ssl_certificate_key wildcard.tsuru.paas.alphagov.co.uk.key
+    - server_name {{ domain_name }}
+    - location / {
+      proxy_pass http://localhost:{{ upstream_port }}/;
+      proxy_redirect default;
+      proxy_redirect http://$host/ https://$host/;
+      proxy_redirect http://$hostname/ https://$host/;
+      proxy_read_timeout 900s;
+      proxy_connect_timeout 15s;
+      proxy_buffering off;
+      }
+  default:
+    - listen 80
+    - return 301 https://$host$request_uri
+nginx_configs:
+  proxy:
+    - proxy_set_header Host $http_host
+    - proxy_set_header X-Real-IP  $remote_addr
+    - proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+    - proxy_set_header X-Forwarded-Proto https

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -7,7 +7,7 @@
     upstream_port: "{{ api_port }}"
     tsuru_api_url: "{{ tsuru_api_external_url }}"
   vars_files:
-    - "ssl_proxy_vars.yml"
+    - "api_ssl_proxy_vars.yml"
   roles:
     - role: tsuru_api
       tags: tsuru_api


### PR DESCRIPTION
Add proxy_buffering off and change proxy_read_timeout to 15 minutes. This way any logs streamed via api server arrive at the client immediately (e.g. app logs, logs from adding platform etc.). Also, connection is not dropped quickly when you try to tail logs and there's no data incoming (previously that would happen after 15s).
