### PR TITLE
[#97198688] Disable nginx proxy buffering

### DIFF
--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -12,6 +12,7 @@ nginx_sites:
       proxy_redirect http://$hostname/ https://$host/;
       proxy_read_timeout 15s;
       proxy_connect_timeout 15s;
+      proxy_buffering off;
       }
   default:
     - listen 80


### PR DESCRIPTION
Buffering is on by default on Nginx. It will cause it to wait for 1KB of output or close of connection before it sends reply back to original requestor. This affects situations where you want to stream response, e.g. when connecting to API server and adding platform or streaming logs. Disabling buffering makes Nginx behave more like ELB or google LBs in being more transparent and not interfering with the data flow from the apps.

More discussion [here](https://github.com/alphagov/tsuru-ansible/pull/90).
