### PR TITLE
[#97381908] Redis runs out of connections with the default settings (2nd step)

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -26,5 +26,5 @@
 # GDS Forked, pull-request sent upstream awaiting merge.
 - name: bennojoy.redis
   src: https://github.com/alphagov/ansible-playbook-redis.git
-  version: v0.0.1
+  version: v0.0.2
 


### PR DESCRIPTION
[Redis runs out of connections with the default settings:  ERR max number of clients reached](https://www.pivotaltracker.com/story/show/97381908)

**What**

Our redis installation currently have a maximum of 128 connections. The tsuru api creates lots of connections and sometimes the platform fails with: `ERR max number of clients reached`

In the [related PR in redis role](https://github.com/alphagov/ansible-playbook-redis/pull/2) the problem is solve by setting a higher number of connections using the feature in Redis which can dynamically set the number of `maxclient` connections based on the current operating systems limit.

**How this PR should be review**

I already reviewed the related functionality of the PR: https://github.com/alphagov/ansible-playbook-redis/pull/2

This PR is about using the new release of the role. To test it, it is enough check that the changes from https://github.com/alphagov/ansible-playbook-redis/pull/2 are in the role copied in `roles/bennojoy.redis` after run `make ansible-galaxy`

**Who should review this PR**
- Anyone on the team with the exception of @actionjack, @mketel or @keymon.
