### PR TITLE
Makefile does noise if it fails opening the vault

### DIFF
--- a/open_the_vault.sh
+++ b/open_the_vault.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-gpg --batch --use-agent --decrypt vault_passphrase.gpg
+gpg --batch --use-agent --quiet --decrypt vault_passphrase.gpg


### PR DESCRIPTION
We retrieve the Tsuru credentials from the ansible vault, but if it
fails getting it, it will not display the error because we capture the
stderr from the `ansible-vault` command in the Makefile.

In this commit we make the `open_the_vault.sh` less verbose to keep
output clean, and we stop capturing the stderr when calling
`ansible-vault`. 

This way, if it fails decrypting it will display the right error and we can 
troubleshoot quickly.

To test it, one can run:

```
GPG_AGENT_INFO=/tmp/test DEPLOY_ENV=ci make test-aws VERBOSE=1
```

That would make gpg fail, so you can see the behaviour with and without this PR.
