### PR TITLE
[#97198688] Output latency smoketest

### DIFF
--- a/spec/command_line_helper.rb
+++ b/spec/command_line_helper.rb
@@ -9,6 +9,17 @@ class CommandLineHelper
     @options = options
   end
 
+  def wait()
+    @tout.join if @tout
+    @terr.join if @terr
+    @exit_status = @wait_thread.value.to_i >> 8 if @wait_thread
+    self
+  end
+
+  def ctrl_c()
+    Process.kill("TERM", @wait_thread.pid)
+  end
+
   protected
 
   def execute_helper_async(*cmd)
@@ -33,17 +44,6 @@ class CommandLineHelper
         @stderr << l
       }
     end
-  end
-
-  def wait()
-    @tout.join if @tout
-    @terr.join if @terr
-    @exit_status = @wait_thread.value.to_i >> 8 if @wait_thread
-    self
-  end
-
-  def ctrl_c()
-    Process.kill("TERM", @wait_thread.pid)
   end
 
   def execute_helper(*cmd)

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -123,6 +123,22 @@ describe "TsuruEndToEnd" do
       end
     end
 
+    it "Should get log output in 3 seconds" do
+      sampleapp_address = @tsuru_command.get_app_address(@sampleapp_name)
+      query = "my_special_query_" + Time.now.to_i.to_s
+      @tsuru_command.tail_app_logs(@sampleapp_name)
+      sleep 1
+      begin
+        response = URI.parse("https://#{sampleapp_address}/" + query).open({ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
+      rescue
+        ()
+      end
+      sleep 3
+      @tsuru_command.ctrl_c()
+      @tsuru_command.wait()
+      expect(@tsuru_command.stdout).to include query
+    end
+
     it "Should be able to connect to the applitation via HTTPS with a valid cert" do
       pending "We don't have a certificate for this :)"
       sampleapp_address = @tsuru_command.get_app_address(@sampleapp_name)

--- a/spec/tsuru_helper.rb
+++ b/spec/tsuru_helper.rb
@@ -90,6 +90,11 @@ class TsuruCommandLine < CommandLineHelper
     execute_helper('tsuru', 'app-info', '-a', app_name)
     (m = /^Repository: (.*)$/.match(@stdout)) ? m[1] : nil
   end
+
+  def tail_app_logs(app_name)
+    execute_helper_async('tsuru','app-log','-a', app_name, '-f')
+  end
+
   def get_app_address(app_name)
     execute_helper('tsuru', 'app-info', '-a', app_name)
     (m = /^Address: (.*)$/.match(@stdout)) ? m[1] : nil


### PR DESCRIPTION
Create log latency smoketest, which tests that the user can see log events within 3 seconds from it being written by the application in the log. The PR also adds all helper classes that make the test possible. This test also indirectly tests that the output of other commands from API server (such as platform add) will likely be also streaming with low latency. (by using the same parts of the infrastructure - load balancers and api servers).

To make this test fail you can comment out `proxy_buffering off;` line in the nginx configs on the API servers and reload nginx.
