### PR TITLE
[#97503258] Revert "Added logic to retry the HTTPS connection test"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ gem 'rspec'
 gem 'serverspec', '~> 2.18.0'
 gem 'ansible_spec'
 gem 'highline'
-gem 'rspec-retry'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,8 +28,6 @@ GEM
     rspec-mocks (3.3.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
-    rspec-retry (0.4.0)
-      rspec-core
     rspec-support (3.3.0)
     serverspec (2.18.0)
       multi_json
@@ -47,7 +45,6 @@ DEPENDENCIES
   ansible_spec
   highline
   rspec
-  rspec-retry
   serverspec (~> 2.18.0)
 
 BUNDLED WITH

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -3,6 +3,7 @@ require 'openssl'
 require 'git_helper'
 require 'tsuru_helper'
 
+
 describe "TsuruEndToEnd" do
   context "deploying an application" do
     before(:all) do
@@ -109,18 +110,10 @@ describe "TsuruEndToEnd" do
       expect(@git_command.exit_status).to eql 0
     end
 
-    it "Should be able to connect to the applitation via HTTPS", :retry => 3, :retry_wait => 1 do
+    it "Should be able to connect to the applitation via HTTPS" do
       sampleapp_address = @tsuru_command.get_app_address(@sampleapp_name)
-      # Capture the exception to print the expection message
-      begin
-        response = URI.parse("https://#{sampleapp_address}/").open({ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
-        expect(response.status).to eq(["200", "OK"])
-      rescue OpenURI::HTTPError => e
-        if RSpec.configuration.verbose
-          $stdout.puts "Request to https://#{sampleapp_address}/ failed with OpenURI::HTTPError: #{e.message}"
-        end
-        raise e
-      end
+      response = URI.parse("https://#{sampleapp_address}/").open({ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
+      expect(response.status).to eq(["200", "OK"])
     end
 
     it "Should get log output in 3 seconds" do

--- a/spec/tsuru_helper.rb
+++ b/spec/tsuru_helper.rb
@@ -2,8 +2,6 @@ require 'tempfile'
 require 'fileutils'
 require 'command_line_helper'
 
-require 'rspec/retry'
-
 RSpec.configure do |c|
   c.add_setting :debug_commands, :default => false
 
@@ -14,8 +12,6 @@ RSpec.configure do |c|
   c.add_setting :tsuru_user, :default => ENV['TSURU_USER']
   c.add_setting :tsuru_pass, :default => ENV['TSURU_PASS']
   c.add_setting :verbose, :default => (ENV['VERBOSE'] and ENV['VERBOSE'].downcase == 'true')
-
-  c.verbose_retry = true if RSpec.configuration.verbose
 
   puts "Running test against: '#{RSpec.configuration.target_api_host}'"
 end


### PR DESCRIPTION
This reverts commit d1b2f792b80cebe8a4cced3bee8bd439d6bcccf9.

No longer seems to be necessary. I suspect that this was fixed by adding a
health check to the demo app, which prevents a route from being added until
the app/container has been confirmed started/working:
- alphagov/flask-sqlalchemy-postgres-heroku-example#4
