### PR TITLE
admin_user must be a valid email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ Required contents for group_vars/all/secure (if you don't know the password)
 ---
 pg_admin_pass: <your postgres admin password>
 pg_apiuser_pass: <password for postgresapi database>
-admin_user: <tsuru admin account to create>
-admin_password: <tsuru admin password to create>
+admin_user: <email address for tsuru admin user>
+admin_password: <password for tsuru admin user>
 
 aws_ssl_key: |
   -----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION
It was not clear when using this repo that the `admin_user` for tsuru must be a valid email address.

If a bare username (e.g. `tsuru_admin`) is used, the following error occurs:

```
TASK: [add admin user] ********************************************************
failed: [10.128.13.146] => {"content": "invalid email\n", "content_type": "text/plain; charset=utf-8", "date": "Fri, 03 Jul 2015 08:34:17 GMT", "failed": true, "redirected": false, "status": 400, "supported_crane": "0.7.0", "supported_tsuru": "0.16.0", "supported_tsuru_admin": "0.10.0", "transfer_encoding": "chunked"}
msg: Status code was not [201, 409]
```

Changing this to a valid email address clears the error and this update to the documentation makes it clear that the username needs to be also in the format of a valid email address.
