### PR TITLE
[#98271560] Postgres log shipping AWS

### DIFF
--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -21,3 +21,13 @@ mongodb_host: "{{ hostvars[groups[mongodb_host_name][0]][ip_field_name] }}"
 
 postgres_host_name: "{{ hosts_prefix }}-tsuru-postgres"
 postgres_host: "{{ hostvars[groups[postgres_host_name][0]][ip_field_name] }}"
+
+# WAL-E Configuration
+enable_postgres_log_shipping: true
+postgresql_wal_level: hot_standby
+postgresql_archive_mode: on
+postgres_backup_s3_bucket: "{{ deploy_env }}-mcp.postgres.backup"
+wal_e_aws_instance_profile: true
+postgresql_archive_command: "/usr/bin/envdir {{ wal_e_envdir }} /usr/local/bin/wal-e {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} wal-push %p"
+wal_e_s3_prefix: "s3://{{ postgres_backup_s3_bucket }}/wal-e"
+wal_e_pgdata_dir: "/var/lib/postgresql/{{ postgresql_version }}/main/"

--- a/postgres.yml
+++ b/postgres.yml
@@ -5,6 +5,7 @@
   sudo_user: root
   roles:
     - ANXS.postgresql
+    - wal_e
   vars:
     #Basic settings
     postgresql_version: 9.3
@@ -52,3 +53,12 @@
       - name: postgresadmin                   # user name
         db: postgres
         role_attr_flags: "SUPERUSER" # role attribute flags
+
+    # WAL-E Configuration
+    wal_e_aws_instance_profile: true
+    wal_e_s3_prefix: "s3://{{ postgres_backup_s3_bucket }}/wal-e"
+    wal_e_pgdata_dir: "/var/lib/postgresql/{{ postgresql_version }}/main/"
+    postgresql_wal_level: hot_standby
+    postgresql_archive_mode: on
+    postgres_backup_s3_bucket: "{{ deploy_env }}-mcp.postgres.backup"
+    postgresql_archive_command: "/usr/bin/envdir {{ wal_e_envdir }} /usr/local/bin/wal-e {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} wal-push %p"

--- a/postgres.yml
+++ b/postgres.yml
@@ -5,7 +5,8 @@
   sudo_user: root
   roles:
     - ANXS.postgresql
-    - wal_e
+    - { role: wal_e, when: enable_postgres_log_shipping is defined and enable_postgres_log_shipping }
+
   vars:
     #Basic settings
     postgresql_version: 9.3
@@ -53,12 +54,3 @@
       - name: postgresadmin                   # user name
         db: postgres
         role_attr_flags: "SUPERUSER" # role attribute flags
-
-    # WAL-E Configuration
-    wal_e_aws_instance_profile: true
-    wal_e_s3_prefix: "s3://{{ postgres_backup_s3_bucket }}/wal-e"
-    wal_e_pgdata_dir: "/var/lib/postgresql/{{ postgresql_version }}/main/"
-    postgresql_wal_level: hot_standby
-    postgresql_archive_mode: on
-    postgres_backup_s3_bucket: "{{ deploy_env }}-mcp.postgres.backup"
-    postgresql_archive_command: "/usr/bin/envdir {{ wal_e_envdir }} /usr/local/bin/wal-e {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} wal-push %p"

--- a/requirements.yml
+++ b/requirements.yml
@@ -24,7 +24,7 @@
   version: v0.0.2
 - name: wal_e
   src: https://github.com/alphagov/ansible-playbook-wal-e.git
-  version: v0.0.1
+  version: v0.0.2
 
 # GDS Forked, pull-request sent upstream awaiting merge.
 - name: bennojoy.redis

--- a/requirements.yml
+++ b/requirements.yml
@@ -22,6 +22,9 @@
 - name: gandalf
   src: https://github.com/alphagov/ansible-playbook-gandalf.git
   version: v0.0.2
+- name: wal_e
+  src: https://github.com/alphagov/ansible-playbook-wal-e.git
+  version: v0.0.1
 
 # GDS Forked, pull-request sent upstream awaiting merge.
 - name: bennojoy.redis

--- a/site-aws.yml
+++ b/site-aws.yml
@@ -11,6 +11,7 @@
     storage_type: "s3"
     s3_region: "eu-west-1"
     s3_bucket: "{{ deploy_env }}-mcp.registry.storage"
+    postgres_backup_s3_bucket: "{{ deploy_env }}-mcp.postgres.backup"
     storage_path: "/"
 
   roles:

--- a/site-aws.yml
+++ b/site-aws.yml
@@ -11,7 +11,6 @@
     storage_type: "s3"
     s3_region: "eu-west-1"
     s3_bucket: "{{ deploy_env }}-mcp.registry.storage"
-    postgres_backup_s3_bucket: "{{ deploy_env }}-mcp.postgres.backup"
     storage_path: "/"
 
   roles:


### PR DESCRIPTION
We want the Postgres server to be able to recover from failure by shipping the logs to secure storage. Postgres uses [WAL-E](https://github.com/wal-e/wal-e) to send full backups and transaction logs to an S3 bucket.
-  We have a new playbook to configure WAL-E: [WAL-E playbook](https://github.com/alphagov/ansible-playbook-wal-e)
-  The required resources were created via terraform in [this PR](https://github.com/alphagov/tsuru-terraform/pull/76)

This particular PR adds log shipping to an AWS environment. GCE is not directly supported in WAL-E, this will be investigated in story #98365398.
# Who should review

Anyone but @saliceti, @keymon , @RichardKnop
# How to review
-  Apply to an AWS environment
-  Check log shipping is configured
-  Test backup + restore
## Check WAL-E and S3 integration

You can check that WAL-E works and is able to upload content by executing the push commands manually from the server:

``` bash
sudo su - postgres

# Base backup:
/usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile backup-push  /var/lib/postgresql/9.3/main/

# WAL push (simulate what postgres runs)
cd /var/lib/postgresql/9.3/main/
# Pick one wal file from pg_xlog/ dir
/usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile wal-push pg_xlog/00000001000000000000000B
```

Check if the configuration is done properly and files are uploaded
WAL runs from 2 places, which the playbook setups.
-  Cron job to do the "full base backup", setup to run once a week:

``` bash
$ cat /etc/cron.d/wal_e_base_backup 
#Ansible: wal_e_base_backup
0 0 * * 1 postgres /usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile backup-push  /var/lib/postgresql/9.3/main/
```
-  Postgres trigger, in `/etc/postgresql/9.3/main/postgresql.conf`. Should include:

``` bash
$ sudo cat /etc/postgresql/9.3/main/postgresql.conf | grep archive_command
archive_command = '/usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile wal-push %p'        # command to use to archive a logfile segment
```

You can check that both jobs run. For the backup job:
1. Setting up the cron job to run every 10 minutes, for example, change /etc/cron.d/wal_e_base_backup and rerun service cron restart to:

``` bash
*/10 * * * * postgres /usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile backup-push  /var/lib/postgresql/9.3/main/
```
1. Check the /var/log/syslog for the output of the wal-e upload of the base backup. Should contain `wal_e.operator.backup`: 

``` bash
wal_e.operator.backup INFO     MSG: start upload postgres version metadata#012        DETAIL: Uploading to s3://my_bucket/wal-e/basebackups_005/base_00000001000000000000000E_00000040/extended_version.txt.#012        STRUCTURED: time=2015-07-03T14:13:57.762694-00 pid=6791
```

For the wal log shipping, Postgres triggers the wal archive when gets enough data (~16MB). But we can for a timeout for testing by changing archive_timeout:
1. Change archive_timeout = 10 in /etc/postgresql/9.3/main/postgresql.conf:

``` bash
sudo sed -i 's/archive_timeout.*/archive_timeout = 10/' /etc/postgresql/9.3/main/postgresql.conf
sudo service postgresql reload
sudo -u postgres psql -c 'show archive_timeout'
```
1. Write something in postgresql.
2. Wait to see the upload in /var/log/postgresql/postgresql-9.3-main.log. Something like:

``` bash
wal_e.worker.upload INFO     MSG: begin archiving a file
    DETAIL: Uploading "pg_xlog/000000020000000000000016" to "s3://bucket/wal-e/wal_005/000000020000000000000016.lzo".
    STRUCTURED: time=2015-07-03T15:46:38.714023-00 pid=14816 action=push-wal key=s3://bucket/wal-e/wal_005/000000020000000000000016.lzo prefix=wal-e/ seg=000000020000000000000016 state=begin
wal_e.worker.upload INFO     MSG: completed archiving to a file 
    DETAIL: Archiving to "s3://bucket/wal-e/wal_005/000000020000000000000016.lzo" complete at 134.87KiB/s. 
    STRUCTURED: time=2015-07-03T15:46:39.366830-00 pid=14816 action=push-wal key=s3://bucket/wal-e/wal_005/000000020000000000000016.lzo prefix=wal-e/ rate=134.87 seg=000000020000000000000016 state=complete
```
## Check if we can restore the backup

We will test with flask application (see demo runbook as example), binding a postgresql instance:
1. Start from a environment with postgresql and WAL-E setup, with the cron job running each 10m and `archive_timeout` settings as described above.
2. Setup flask with a DB binding.
3. Add some posts to flask app (login: admin, pass: default)
4. Get a Base backup. For that wait > 10m for the cronjob to run or just login on the postgresql DB server and run the cron command manually as postgresql: `sudo -u postgres /usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile backup-push /var/lib/postgresql/9.3/main/`
5. Add some more posts in flask demo app, and wait some seconds for the DB to upload the WAL files (check logs if desired, as described before)
6. Reprovision the postgresql DB, using terraform and ansible:
    `bash
    cd tsuru-terraform/aws
    terraform taint aws_instance.postgres
    terraform apply -var env=....................... -var force-destroy=true
    cd ../../tsuru-ansible
    make aws DEPLOY_ENV=russ ARGS='-l *postgres*'
`
7. Flask now should fail because everything is broken, no DB exists, etc.
Now restore the backup, following the instructions from postgres and WAL-E:
- ssh on the postgres server
- Stop postgres and delete the data

``` bash
sudo service postgresql stop
mv /var/lib/postgresql/9.3/main /var/lib/postgresql/9.3/main.bak
mkdir /var/lib/postgresql/9.3/main
chmod 0700 "/var/lib/postgresql/9.3/main"
```
- Check the WAL-E latest base backup:

``` bash
$ sudo -u postgres /usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile backup-list
name    last_modified    expanded_size_bytes    wal_segment_backup_start    wal_segment_offset_backup_start    wal_segment_backup_stop    wal_segment_offset_backup_stop
base_00000001000000000000000A_00000040    2015-07-02T16:05:09.000Z        00000001000000000000000A    00000040        
base_00000001000000000000000E_00000040    2015-07-03T14:14:01.000Z        00000001000000000000000E    00000040
```
- Pull the latest one:

``` bash
/usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile backup-fetch /var/lib/postgresql/9.3/main/ base_00000001000000000000000A_00000040
```
- Create a file `/var/lib/postgresql/9.3/main/recovery.conf` to tell postgresql to trigger recovery and how to pull the WAL files:

``` bash
cat <<"EOF"  | sudo -u postgres tee /var/lib/postgresql/9.3/main/recovery.conf
restore_command ='/usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile wal-fetch "%f" "%p"'
EOF
```
- Start postgres: sudo service start postgresql it should take some time and recover the DB.
- Refresh flask app (retry some times because the DB pool might have dead connections)
