### PR TITLE
[#97818382] Add tests for Tsuru API healthchecks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ check-target-api-host-var:
 
 test: check-env-var check-target-api-host-var load-tsuru-creds
 	@bundle install --path vendor/bundle --quiet
-	@TARGET_API_HOST=${TARGET_API_HOST} \
+	@SSL_CERT_FILE=$(shell python -m certifi) \
+	TARGET_API_HOST=${TARGET_API_HOST} \
 	TSURU_USER=${TSURU_USER} \
 	TSURU_PASS=${TSURU_PASS} \
 	bundle exec rake endtoend:all

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -1,3 +1,4 @@
+require 'net/http'
 require 'open-uri'
 require 'openssl'
 require 'git_helper'
@@ -13,10 +14,10 @@ describe "TsuruEndToEnd" do
 
   describe "tsuru API" do
     it "should pass healthchecks for all components" do
-      response = URI.parse("#{@tsuru_api_url}/healthcheck/?check=all").open()
-      expect(response.status).to eq(["200", "OK"])
+      response = Net::HTTP.get_response(URI.parse("#{@tsuru_api_url}/healthcheck/?check=all"))
+      expect(response.code.to_i).to eq(200)
 
-      component_lines = response.read.split("\n")
+      component_lines = response.body.split("\n")
       expect(component_lines.size).to be >= 3
       component_lines.each do |component_line|
         expect(component_line).to match(%r{:\sWORKING\s})

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -12,16 +12,22 @@ describe "TsuruEndToEnd" do
     @tsuru_api_url_insecure = "http://#{@tsuru_api_host}:8080"
   }
 
-  describe "tsuru API" do
-    it "should pass healthchecks for all components" do
-      response = Net::HTTP.get_response(URI.parse("#{@tsuru_api_url}/healthcheck/?check=all"))
-      expect(response.code.to_i).to eq(200)
+  describe "healthchecks" do
+    let(:healthcheck_response) {
+      Net::HTTP.get_response(URI.parse("#{@tsuru_api_url}/healthcheck/?check=all"))
+    }
 
-      component_lines = response.body.split("\n")
+    it "should return each component as WORKING" do
+      component_lines = healthcheck_response.body.split("\n")
       expect(component_lines.size).to be >= 3
+
       component_lines.each do |component_line|
         expect(component_line).to match(%r{:\sWORKING\s})
       end
+    end
+
+    it "should return status code of 200 to indicate all components are healthy" do
+      expect(healthcheck_response.code.to_i).to eq(200)
     end
   end
 


### PR DESCRIPTION
To test that all of the components (MongoDB, Router, Registry, etc) are
passing health checks by using this endpoint:
- http://docs.tsuru.io/en/master/reference/api.html#full-healthcheck-of-all-tsuru-components

Technically we don't need to check the output because the endpoint should
return a non-200 response if any of the components are not `WORKING`.
However for completeness I am checking that that we have at least three
lines of output so that the `each` loop gets called and that each line
contains `WORKING` in roughly the right place.

I've pulled some variables that I need into the outer `describe` block so
that I can use them across both contexts. I've also referenced
`@tsuru_api_host`, since we're setting it, rather than going back to
`RSpec.configuration.target_api_host` each time.
#### Use certifi CA bundle for end-to-end tests

Otherwise `open-uri` raises a certificate verify exception for the GlobalSign
certificate that we have on the API when running the tests from Mac OS X:

```
Failures:

  1) TsuruEndToEnd tsuru API should pass healthchecks for all components
     Failure/Error: response = URI.parse("#{@tsuru_api_url}/healthcheck/?check=all").open()
     OpenSSL::SSL::SSLError:
       SSL_connect returned=1 errno=0 state=unknown state: certificate verify failed
     # ./spec/endtoend/endtoend_spec.rb:15:in `block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.2.0/gems/rspec-retry-0.4.0/lib/rspec/retry.rb:43:in `block (3 levels) in apply'
     # ./vendor/bundle/ruby/2.2.0/gems/rspec-retry-0.4.0/lib/rspec/retry.rb:34:in `times'
     # ./vendor/bundle/ruby/2.2.0/gems/rspec-retry-0.4.0/lib/rspec/retry.rb:34:in `block (2 levels) in apply'
```

We could install the Ruby version of `certifi` certificate path, however it
seems to require monkey-patching to tell `open-uri` to always use that CA path.
Using the environment variable is easier and at least consistent with how we
run Ansible.
