### PR TITLE
[#98450546] Set proxy timeout to default

### DIFF
--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -10,7 +10,6 @@ nginx_sites:
       proxy_redirect default;
       proxy_redirect http://$host/ https://$host/;
       proxy_redirect http://$hostname/ https://$host/;
-      proxy_read_timeout 15s;
       proxy_connect_timeout 15s;
       proxy_buffering off;
       }


### PR DESCRIPTION
For some reason, we had proxy_read_timeout set to 15s. This was too short for some operations and causing problems when:
- tailing logs and there was no events for more thatn 15s [#97521746](https://www.pivotaltracker.com/n/projects/1275640/stories/97521746)
- deploying app and it took more than 15s for API to clone the repo [#98450546](https://www.pivotaltracker.com/n/projects/1275640/stories/98450546)
- deploying app and it took more than 15s when uploading final package to registry [#97521746](https://www.pivotaltracker.com/n/projects/1275640/stories/97521746)

Hence reverting proxy_read_timeout setting to default, which is 60s. This fixes the issues described in the above tracker stories.
