### PR TITLE
Make SSL cert file name correspond to contents

### DIFF
--- a/ssl_proxy_pre.yml
+++ b/ssl_proxy_pre.yml
@@ -5,6 +5,6 @@
 - name: Create Nginx Directory
   file: dest=/etc/nginx mode=755 owner=root group=root state=directory
 - name: Upload Unencrypted Key File
-  copy: content="{{ ssl_key }}" dest=/etc/nginx/wildcard.tsuru.paas.alphagov.co.uk.key owner=root group=root
+  copy: content="{{ ssl_key }}" dest=/etc/nginx/wildcard.{{ domain_name }}.key owner=root group=root
 - name: Upload Unencrypted Cert File
-  copy: content="{{ ssl_crt }}" dest=/etc/nginx/wildcard.tsuru.paas.alphagov.co.uk.site.chain.crt owner=root group=root
+  copy: content="{{ ssl_crt }}" dest=/etc/nginx/wildcard.{{ domain_name }}.site.chain.crt owner=root group=root

--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -2,8 +2,8 @@
 nginx_sites:
   ssl_reverse_proxy:
     - listen 443 ssl
-    - ssl_certificate wildcard.tsuru.paas.alphagov.co.uk.site.chain.crt
-    - ssl_certificate_key wildcard.tsuru.paas.alphagov.co.uk.key
+    - ssl_certificate wildcard.{{ domain_name }}.site.chain.crt
+    - ssl_certificate_key wildcard.{{ domain_name }}.key
     - server_name {{ domain_name }}
     - location / {
       proxy_pass http://localhost:{{ upstream_port }}/;


### PR DESCRIPTION
Currently the SSL certificate files for nginx are always named wildcard.tsuru.paas.alphagov.co.uk.key and wildcard.tsuru.paas.alphagov.co.uk.site.chain.crt, which is correct in AWS but quite confusing in GCE, even though the files contain correct GCE cert in the second case. Change the file names to use appropriate {{ domain_name }}.

Tested on AWS only because I can't currently get GCE env.
