### PR TITLE
Remove http upload object limit

### DIFF
--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -11,6 +11,7 @@ nginx_sites:
       proxy_redirect http://$host/ https://$host/;
       proxy_redirect http://$hostname/ https://$host/;
       proxy_read_timeout 15s;
+      client_max_body_size 0;
       proxy_connect_timeout 15s;
       proxy_buffering off;
       }


### PR DESCRIPTION
NGINX has default client_max_body_size set to 1MB. If you try to deploy app using tsuru app-deploy and there's any object larger than 1 MB (e.g. any media, pictures, binaries, packages), you get a 413 error. This commit removes the limit checking, removing another point of proxy interference with the platform/client communication.
