### PR TITLE
[#98091344] add grafana metrics collection

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -62,4 +62,5 @@
 
 - include: postgres.yml
 - include: router.yml
+- include: influx_grafana.yml
 - include: post-install.yml

--- a/files/datasource.sh
+++ b/files/datasource.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+COOKIEJAR=$(mktemp)
+trap 'unlink ${COOKIEJAR}' EXIT
+
+function grafana_has_data_source {
+  setup_grafana_session
+  curl --silent --cookie "$COOKIEJAR" "$(grafana_url)datasources" \
+    | grep "{\"name\":\"${1}\"}" --silent
+}
+
+function influxfb_remote_url {
+  echo -e "http://localhost:8086/"
+}
+
+function grafana_url {
+  echo -e http://localhost:3000/api/
+}
+ 
+# Used for this script to talk to the InfluxDB API
+function influxfb_local_url {
+  echo -e "http://localhost:8086/"
+}
+
+
+function setup_grafana_session {
+  if ! curl -H 'Content-Type: application/json;charset=UTF-8' \
+    --data-binary '{"user":"admin","email":"","password":"admin"}' \
+    --cookie-jar "$COOKIEJAR" \
+    'http://localhost:3000/login' > /dev/null 2>&1 ; then
+    echo
+    error "Grafana Session: Couldn't store cookies at ${COOKIEJAR}"
+  fi
+}
+function grafana_create_data_source {
+  setup_grafana_session
+  curl --cookie "$COOKIEJAR" \
+       -X PUT \
+       --silent \
+       -H 'Content-Type: application/json;charset=UTF-8' \
+       --data-binary "{\"name\":\"${1}\",\"type\":\"influxdb\",\"url\":\"$(influxfb_remote_url)\",\"access\":\"proxy\",\"IsDefault\":true,\"database\":\"${1}\",\"user\":\"${1}\",\"password\":\"${1}\"}" \
+       "$(grafana_url)datasources" 2>&1 | grep 'Datasource added' --silent;
+}
+
+function setup_grafana {
+  if grafana_has_data_source "$1"; then
+    info "Grafana: Data source ${1} already exists"
+  else
+    if grafana_create_data_source "$1"; then
+      success "Grafana: Data source ${1} created"
+    else
+      error "Grafana: Data source ${1} could not be created"
+    fi
+  fi
+}
+ 
+function success {
+  echo "$(tput setaf 2)""$*""$(tput sgr0)"
+}
+ 
+function info {
+  echo "$(tput setaf 3)""$*""$(tput sgr0)"
+}
+ 
+function error {
+  echo "$(tput setaf 1)""$*""$(tput sgr0)" 1>&2
+}
+ 
+function setup {
+  setup_grafana "$1"
+}
+
+setup $1

--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -10,6 +10,10 @@ docker_port: 4243
 
 hipache_host_external_lb: "{{ deploy_env }}-hipache.{{ domain_name }}"
 
+influxdb_database: influxdb
+influxdb_user: influxdb
+influx_pass: influxdb
+
 gandalf_host_external: "{{ deploy_env }}-gandalf.{{ domain_name }}"
 gandalf_port: 8080
 

--- a/influx_grafana.yml
+++ b/influx_grafana.yml
@@ -11,7 +11,7 @@
     - role: Stouts.grafana
   post_tasks:
     - name: Copy grafana API control script
-      copy: src=datasource.sh dest=/usr/local/bin/datasource.sh mode=0750 owner=root group=root
+      copy: src=files/datasource.sh dest=/usr/local/bin/datasource.sh mode=0750 owner=root group=root
     - name: Add influx datasource to grafana
       shell: /usr/local/bin/datasource.sh {{ influxdb_database }}
 

--- a/influx_grafana.yml
+++ b/influx_grafana.yml
@@ -10,6 +10,8 @@
     - role: telegraf
     - role: Stouts.grafana
   post_tasks:
+    - name: Copy grafana API control script
+      copy: src=datasource.sh dest=/usr/local/bin/datasource.sh mode=0750 owner=root group=root
     - name: Add influx datasource to grafana
       shell: /usr/local/bin/datasource.sh {{ influxdb_database }}
 

--- a/influx_grafana.yml
+++ b/influx_grafana.yml
@@ -1,0 +1,19 @@
+- hosts: "{{ hosts_prefix }}-influx-grafana*"
+  sudo: yes
+  vars:
+    influxdb_version: latest
+  tasks: # The influxdb and telegraf packages disagree on ownership of /var/run/influxdb - Telegraf Issue #37
+    - name: Create /etc/default/telegraf to fix conflict between influxdb and telegraf packages
+      copy: dest=/etc/default/telegraf mode=0644 content="USER=influxdb\nGROUP=influxdb\n"
+  roles:
+    - role: influxdb
+    - role: telegraf
+    - role: Stouts.grafana
+  post_tasks:
+    - name: Add influx datasource to grafana
+      shell: /usr/local/bin/datasource.sh {{ influxdb_database }}
+
+- hosts: "{{ hosts_prefix }}-*"
+  sudo: yes
+  roles:
+    - telegraf

--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -31,3 +31,6 @@ wal_e_aws_instance_profile: true
 postgresql_archive_command: "/usr/bin/envdir {{ wal_e_envdir }} /usr/local/bin/wal-e {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} wal-push %p"
 wal_e_s3_prefix: "s3://{{ postgres_backup_s3_bucket }}/wal-e"
 wal_e_pgdata_dir: "/var/lib/postgresql/{{ postgresql_version }}/main/"
+
+influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"
+influxdb_url: "http://{{ hostvars[groups[influxdb_host_name][0]][ip_field_name] }}:8086"

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -21,3 +21,6 @@ mongodb_host: "{{ hostvars[mongodb_host_name][ip_field_name] }}"
 
 postgres_host_name: "{{ hosts_prefix }}-tsuru-postgres"
 postgres_host: "{{ hostvars[postgres_host_name][ip_field_name] }}"
+
+influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"
+influxdb_url: "http://{{ hostvars[influxdb_host_name][ip_field_name] }}:8086"

--- a/requirements.yml
+++ b/requirements.yml
@@ -8,6 +8,8 @@
   version: v1.1.2
 - src: greendayonfire.mongodb
   version: v1.2.2
+- src: Stouts.grafana
+  version: 2.0.1
 
 # GDS created and maintained playbooks
 - name: docker_server
@@ -25,6 +27,12 @@
 - name: wal_e
   src: https://github.com/alphagov/ansible-playbook-wal-e.git
   version: v0.0.2
+- name: influxdb
+  src: https://github.com/alphagov/ansible-playbook-influxdb.git
+  version: v0.0.1
+- name: telegraf
+  src: https://github.com/alphagov/ansible-playbook-telegraf.git
+  version: v0.0.1
 
 # GDS Forked, pull-request sent upstream awaiting merge.
 - name: bennojoy.redis


### PR DESCRIPTION
[Add metrics capture to core components](https://www.pivotaltracker.com/story/show/98091344)

**What**

In order to perform load testing we need metrics on the core components - API, Gandalf, Hipache, Docker and Archive Server.

This PR sets up a [grafana](https://github.com/grafana/grafana) server with an [influxdb](https://github.com/influxdb/influxdb) time series database and it installs the [telegraf agent](https://github.com/influxdb/telegraf) on each server.

**How this PR should be reviewed**

This PR should reviewed in the following context:
- I need some additional ansible playbooks to configure the metrics server and telegraf server agent for reporting metrics into InfluxDB.
- I want to create a new ansible playbook that will be used to configure `grafana`, `influxdb` and `telegraf`
- I want to add platform specific variables for the `telegraf`agent to know where to send it's metrics data
- I want to add some `influxdb` specific variables for use later on
- I want to enable the new metrics collection service
- Instead of creating a custom fork of the stouts.grafana, I have decided to move that functionality into this repository
- I want to revert back to using the official stouts.grafana rather than my custom fork of it now that I have done the above

**How to test this PR**

You will need to spin up a new environment and point your browser at:

On AWS:

`http://<environment-name>-grafana.tsuru.paas.alphagov.co.uk:3000/`

On GCE:

`http://<environment-name>-grafana.tsuru2.paas.alphagov.co.uk:3000/`

Then: 
- Click on 'Home' in the top left hand corner of the Grafana page and then click the '+New' button at the bottom of the panel to add a new Dashboard
- Click the small green rectangle which has appeared in the top left hand corner of the new Dashboard, Choose 'Add Panel->Graph'
- Click on the title of the new graph 'no title (click here)' and choose 'edit'
- In the metrics editor, click on 'select metric' to choose the metric you wish to see. 
- Click on 'Select Tag' and choose the 'Host' tag
- Click on 'Select Tag Value' to bring up the drop-down list of hosts for that metric
- Click on 'Back to Dashboard' when done.

**Who should review this PR**
- Anyone in the core team except @jimconner who I paired with :-p

**Notes**

There will be a follow up story after this one to use encrypted values for the `influxdb_user` and `influxdb_password`. I have not done this within this story because it cause a conflict with the `ansible vault`
