### PR TITLE
[#98109110] Update ssh template to use ubuntu NAT user on AWS

### DIFF
--- a/ssh.config.template
+++ b/ssh.config.template
@@ -1,5 +1,5 @@
 Host DEPLOY_ENV-nat.tsuru.paas.alphagov.co.uk
-    User                   ec2-user
+    User                   ubuntu
     HostName               DEPLOY_ENV-nat.tsuru.paas.alphagov.co.uk
     ProxyCommand           none
     StrictHostKeyChecking  no
@@ -12,7 +12,7 @@ Host DEPLOY_ENV-nat.tsuru.paas.alphagov.co.uk
 Host 10.128.*.*
     ServerAliveInterval    60
     TCPKeepAlive           yes
-    ProxyCommand           ssh -F ssh.config -q -A ec2-user@DEPLOY_ENV-nat.tsuru.paas.alphagov.co.uk nc %h %p
+    ProxyCommand           ssh -F ssh.config -q -A ubuntu@DEPLOY_ENV-nat.tsuru.paas.alphagov.co.uk nc %h %p
     ControlMaster          auto
     ControlPath            ~/.ssh/mux-%r@%h:%p
     ControlPersist         8h


### PR DESCRIPTION
AWS NAT is no longer custom AWS linux box, but runs instead on ubuntu like all other hosts and GCE NAT. Update ssh template to reflect these changes.

Depends on https://github.com/alphagov/tsuru-terraform/pull/80
