### PR TITLE
[#98109110] Suspend and resume environments via make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ ssh.config
 .ansible-galaxy.check
 .diff-vault.fifo
 vendor/
+ansible-ec2.cache
+ansible-ec2.index

--- a/Makefile
+++ b/Makefile
@@ -103,11 +103,11 @@ start-gce: check-env-var render-ssh-config
 	SSL_CERT_FILE=$(shell python -m certifi) ansible-playbook -i gce.py gce-wake.yml -e deploy_env=${DEPLOY_ENV}
 
 suspend-aws: check-env-var render-ssh-config
-	ansible all -i ec2.py -a 'sudo poweroff' -l "!tag_Name_${DEPLOY_ENV}-tsuru-nat:tag_Name_${DEPLOY_ENV}-tsuru-*"
-	ansible all -i ec2.py -a 'sudo poweroff' -l "tag_Name_${DEPLOY_ENV}-tsuru-nat"
+	ansible all -i ec2.py -a 'sudo poweroff' -l "!~^tag_Name_${DEPLOY_ENV}-tsuru-nat:~^tag_Name_${DEPLOY_ENV}-"
+	ansible all -i ec2.py -a 'sudo poweroff' -l "~^tag_Name_${DEPLOY_ENV}-tsuru-nat"
 
 suspend-gce: check-env-var render-ssh-config
 	SSL_CERT_FILE=$(shell python -m certifi) \
-	ansible all -i gce.py -a 'sudo poweroff' -l "!${DEPLOY_ENV}-tsuru-nat:${DEPLOY_ENV}-tsuru-*"
+	ansible all -i gce.py -a 'sudo poweroff' -l "!~^${DEPLOY_ENV}-tsuru-nat:~^${DEPLOY_ENV}-"
 	SSL_CERT_FILE=$(shell python -m certifi) \
-	ansible all -i gce.py -a 'sudo poweroff' -l "${DEPLOY_ENV}-tsuru-nat"
+	ansible all -i gce.py -a 'sudo poweroff' -l "~^${DEPLOY_ENV}-tsuru-nat"

--- a/Makefile
+++ b/Makefile
@@ -100,12 +100,14 @@ start-aws: check-env-var render-ssh-config
 	ansible-playbook -i ec2.py ec2-wake.yml -e deploy_env=${DEPLOY_ENV}
 
 start-gce: check-env-var render-ssh-config
-	ansible-playbook -i gce.py gce-wake.yml -e deploy_env=${DEPLOY_ENV}
+	SSL_CERT_FILE=$(shell python -m certifi) ansible-playbook -i gce.py gce-wake.yml -e deploy_env=${DEPLOY_ENV}
 
 suspend-aws: check-env-var render-ssh-config
 	ansible all -i ec2.py -a 'sudo poweroff' -l "!tag_Name_${DEPLOY_ENV}-tsuru-nat:tag_Name_${DEPLOY_ENV}-tsuru-*"
 	ansible all -i ec2.py -a 'sudo poweroff' -l "tag_Name_${DEPLOY_ENV}-tsuru-nat"
 
 suspend-gce: check-env-var render-ssh-config
+	SSL_CERT_FILE=$(shell python -m certifi) \
 	ansible all -i gce.py -a 'sudo poweroff' -l "!${DEPLOY_ENV}-tsuru-nat:${DEPLOY_ENV}-tsuru-*"
+	SSL_CERT_FILE=$(shell python -m certifi) \
 	ansible all -i gce.py -a 'sudo poweroff' -l "${DEPLOY_ENV}-tsuru-nat"

--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,17 @@ diff-vault:
 		<(ansible-vault view ${VAULT_FIFO} 2>/dev/null) \
 		<(ansible-vault view ${VAULT_FILE} 2>/dev/null) \
 		|| [ $$? -eq 1 ]'
+
+start-aws: check-env-var render-ssh-config
+	ansible-playbook -i ec2.py ec2-wake.yml -e deploy_env=${DEPLOY_ENV}
+
+start-gce: check-env-var render-ssh-config
+	ansible-playbook -i gce.py gce-wake.yml -e deploy_env=${DEPLOY_ENV}
+
+suspend-aws: check-env-var render-ssh-config
+	ansible all -i ec2.py -a 'sudo poweroff' -l "!tag_Name_${DEPLOY_ENV}-tsuru-nat:tag_Name_${DEPLOY_ENV}-tsuru-*"
+	ansible all -i ec2.py -a 'sudo poweroff' -l "tag_Name_${DEPLOY_ENV}-tsuru-nat"
+
+suspend-gce: check-env-var render-ssh-config
+	ansible all -i gce.py -a 'sudo poweroff' -l "!${DEPLOY_ENV}-tsuru-nat:${DEPLOY_ENV}-tsuru-*"
+	ansible all -i gce.py -a 'sudo poweroff' -l "${DEPLOY_ENV}-tsuru-nat"

--- a/ec2-wake.yml
+++ b/ec2-wake.yml
@@ -1,0 +1,19 @@
+---
+
+# Change state of all instances in the EC2 environment
+  - hosts: localhost
+    tasks:
+      - name: Deploy ec2.py
+        file: src=ec2.py dest=./ec2.py mode=0744
+      - name: Get stopped instances
+        shell: "./ec2.py --stopped --refresh-cache"
+        register: ec2_hosts_raw
+      - set_fact:
+          ec2_hosts: "{{ ec2_hosts_raw.stdout|from_json }}"
+      - name: Wake instances
+        ec2:
+          region: "eu-west-1"
+          state: 'running'
+          instance_ids: "{{ item.value.ec2_id }}"
+        when: item.value.ec2_tag_Name is defined and item.value.ec2_tag_Name.find("{{ deploy_env }}-tsuru-") != -1
+        with_dict: ec2_hosts._meta.hostvars

--- a/ec2-wake.yml
+++ b/ec2-wake.yml
@@ -15,5 +15,5 @@
           region: "eu-west-1"
           state: 'running'
           instance_ids: "{{ item.value.ec2_id }}"
-        when: item.value.ec2_tag_Name is defined and item.value.ec2_tag_Name.find("{{ deploy_env }}-tsuru-") != -1
+        when: item.value.ec2_tag_Name is defined and item.value.ec2_tag_Name | match("^{{ deploy_env }}-*")
         with_dict: ec2_hosts._meta.hostvars

--- a/ec2.ini
+++ b/ec2.ini
@@ -60,7 +60,7 @@ all_rds_instances = False
 # will be written to this directory:
 #   - ansible-ec2.cache
 #   - ansible-ec2.index
-cache_path = ~/.ansible/tmp
+cache_path = .
 
 # The number of seconds a cache file is considered valid. After this many
 # seconds, a new API call will be made, and the cache file will be updated.

--- a/ec2.py
+++ b/ec2.py
@@ -286,6 +286,8 @@ class Ec2Inventory(object):
         parser = argparse.ArgumentParser(description='Produce an Ansible Inventory file based on EC2')
         parser.add_argument('--list', action='store_true', default=True,
                            help='List instances (default: True)')
+        parser.add_argument('--stopped', action='store_true', default=False,
+                           help='List instances (default: False)')
         parser.add_argument('--host', action='store',
                            help='Get all the variables about a specific instance')
         parser.add_argument('--refresh-cache', action='store_true', default=False,
@@ -379,8 +381,12 @@ class Ec2Inventory(object):
         ''' Adds an instance to the inventory and index, as long as it is
         addressable '''
 
-        # Only want running instances unless all_instances is True
-        if not self.all_instances and instance.state != 'running':
+        # Only want running instances unless all_instances is True and not interested in stopped
+        if not self.all_instances and instance.state != 'running' and not self.args.stopped:
+            return
+
+        # Only want stopped instances unless all_instances is True and interested in stopped
+        if not self.all_instances and instance.state != 'stopped' and self.args.stopped:
             return
 
         # Select the best destination address

--- a/gce-wake.yml
+++ b/gce-wake.yml
@@ -1,0 +1,15 @@
+---
+
+# Start all the instances in the specified GCE deployment
+  - hosts: localhost
+    tasks:
+      - name: Deploy gce.py
+        file: src=gce.py dest=./gce.py mode=0744
+      - name: Deploy secrets.py
+        file: src=secrets.py dest=./secrets.py mode=0700
+
+      - name: Wake instances
+        shell: "./gce.py --start {{ item }}"
+        when: '"{{ deploy_env }}-tsuru-" in item'
+        with_items: groups['status_terminated']
+

--- a/gce-wake.yml
+++ b/gce-wake.yml
@@ -10,6 +10,6 @@
 
       - name: Wake instances
         shell: "./gce.py --start {{ item }}"
-        when: '"{{ deploy_env }}-tsuru-" in item'
+        when: item | match("^{{ deploy_env }}-*")
         with_items: groups['status_terminated']
 

--- a/gce.py
+++ b/gce.py
@@ -110,6 +110,9 @@ class GceInventory(object):
         self.parse_cli_args()
         self.driver = self.get_gce_driver()
 
+        if self.args.start:
+            sys.exit(not(self.start_instance(self.args.start)))
+
         # Just display data for specific host
         if self.args.host:
             print self.json_format_dict(self.node_to_dict(
@@ -199,6 +202,8 @@ class GceInventory(object):
                            help='List instances (default: True)')
         parser.add_argument('--host', action='store',
                            help='Get all information about an instance')
+        parser.add_argument('--start', action='store',
+                           help='Start the specified instance')
         parser.add_argument('--pretty', action='store_true', default=False,
                            help='Pretty format (default: False)')
         self.args = parser.parse_args()
@@ -246,6 +251,15 @@ class GceInventory(object):
             return self.driver.ex_get_node(instance_name)
         except Exception, e:
             return None
+
+    def start_instance(self, instance_name):
+        '''Starts the specified instance '''
+        try:
+            instance = self.driver.ex_get_node(instance_name)
+        except Exception, e:
+            return e
+
+        return self.driver.ex_start_node(instance)
 
     def group_instances(self):
         '''Group all instances'''


### PR DESCRIPTION
Adding functionality to suspend and resume environments:
- enhance gce.py script to be able to start instances
- enhance ec2.py script to list only stopped instances
- add ansible playbook to start all VMs in a specified environment on EC2
- add ansible playbook to start all VMs in a specified environment on GCE
- add makefile targets to call suspend and resume actions on AWS and GCE

Depends on https://github.com/alphagov/tsuru-ansible/pull/113
