### PR TITLE
[#98748824] Bump and pin docker server

### DIFF
--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -7,6 +7,7 @@ api_port: 8080
 docker_registry_host: "{{ deploy_env }}-docker-registry.{{ domain_name }}"
 docker_registry_port: 6000
 docker_port: 4243
+docker_version: 1.7.0
 
 hipache_host_external_lb: "{{ deploy_env }}-hipache.{{ domain_name }}"
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -14,7 +14,7 @@
 # GDS created and maintained playbooks
 - name: docker_server
   src: https://github.com/alphagov/ansible-playbook-docker_server.git
-  version: v0.0.2
+  version: v0.1.0
 - name: hipache
   src: https://github.com/alphagov/ansible-playbook-hipache.git
   version: v0.0.2


### PR DESCRIPTION
#### Bump docker_server playbook to v0.1.0

Which includes support for:
- pinning the package version
- binding the default UNIX socket in addition to TCP
#### Pin docker server to 1.7.0

To prevent unintended and breaking upgrades whenever `get.docker.com` make a
new package available.
