### PR TITLE
Specify team when creating new apps.

### DIFF
--- a/post-install.yml
+++ b/post-install.yml
@@ -85,7 +85,7 @@
     - name: Tsuru app-create dashboard
       ignore_errors: yes
       shell: >
-        tsuru app-create dashboard python
+        tsuru app-create dashboard python -t admin
       when: "not 'dashboard' in tsuru_apps.stdout"
     - name: Get gandalf repo for dashboard
       shell: >
@@ -111,7 +111,7 @@
     - name: Tsuru app-create postgresapi
       ignore_errors: yes
       shell: >
-        tsuru app-create postgresapi python
+        tsuru app-create postgresapi python -t admin
       when: "not 'postgresapi' in tsuru_apps.stdout"
 
     - name: Git pull postgresapi


### PR DESCRIPTION
**What**

Our demo environment has identified a weakness in our current tsuru-ansible
scripts whereby we've never considered the case that the admin user may be a
member of more than one team. If this is the case than a `tsuru app-create` will
fail with an `Error: You belong to more than one team, choose one to be owner for this app.`

This commit adds the `-t` flag to the app-create commands to specify the `admin` team during
the post-install.yml ansible run.

**How to review this PR**

I've created the PR to be reviewed in the following context:
- I need the post-install stage of the ansible run to work correctly regardless of the number of teams the admin user belongs to.

**Who should review this PR**
- Anyone in the core team
