### PR TITLE
Add support to smoke tests for admin user being in multiple teams

### DIFF
--- a/spec/tsuru_helper.rb
+++ b/spec/tsuru_helper.rb
@@ -67,7 +67,7 @@ class TsuruCommandLine < CommandLineHelper
   end
 
   def service_add(service_name, service_instance_name, plan)
-    execute_helper('tsuru', 'service-add', service_name, service_instance_name, plan)
+    execute_helper('tsuru', 'service-add', service_name, service_instance_name, plan, '-t', 'admin')
   end
 
   def service_remove(service_instance_name)

--- a/spec/tsuru_helper.rb
+++ b/spec/tsuru_helper.rb
@@ -51,7 +51,7 @@ class TsuruCommandLine < CommandLineHelper
   end
 
   def app_create(app_name, platform)
-    execute_helper('tsuru', 'app-create', app_name, platform)
+    execute_helper('tsuru', 'app-create', app_name, platform, '-t', 'admin')
   end
 
   def app_remove(app_name)


### PR DESCRIPTION
**What**

When a Tsuru user is a member of multiple teams, they must specify at the time of app-create which team that app belongs to by using the `-t <teamname>` parameter on the end of the command.
Our demo environment has the admin user belonging to multiple teams, so the smoke tests are currently failing as app-create is not specifying a team.

This PR adds the required `-t admin` to the end of the app-create helper function:

**How to review this PR**

I've created the PR to be reviewed in the following context:
- I need smoke tests to correctly deploy the sampleapp application when the admin user belongs to multiple teams.

**Who should review this PR**
- Anyone in the core team
