### PR TITLE
[98450546] Add a fake platform to do 31s delay while deploy

### DIFF
--- a/spec/test_platforms/README.md
+++ b/spec/test_platforms/README.md
@@ -1,0 +1,12 @@
+Custom platforms for tsuru debuging and testing
+===============================================
+
+This repository contains some custom platforms for testing and debuging
+[tsuru](http://tsuru.io).
+
+Delay unit platform
+-------------------
+
+This is a fake platforms that does `sleep` when calling the `tsuru_unit_agent`
+to test timeouts.
+

--- a/spec/test_platforms/delay_unit_platform/Dockerfile
+++ b/spec/test_platforms/delay_unit_platform/Dockerfile
@@ -1,0 +1,7 @@
+from	ubuntu:14.04
+# Create a fake tsuru_unit_agent
+run echo "#!/bin/sh\nsleep 31" > /usr/local/bin/tsuru_unit_agent
+run	chmod +x /usr/local/bin/tsuru_unit_agent
+# Add the ubuntu user
+run useradd -m ubuntu -s /bin/bash
+run echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers


### PR DESCRIPTION
## Context

In order to implement a test on the timeout while deploying
applications, we need to simulate a delay > 30s while deploying, which
will trigger the heartbeat of the tsuru API.

The `tsuru_unit_agent` implements other heartbeat of 5s, so we need to
catch the calls to `tsuru_unit_agent`.

This is a non functional platform, it just does sleep 30 for every
`tsuru_unit_agent` execution.
## Who can review this

Anybody but @keymon or @mtekel 
## Dependencies

Once this PR is merged, we need to [update the actual test](https://github.com/alphagov/tsuru-ansible/blob/98450546_timeout_test/spec/integration/integration_spec.rb#L61), to refer to the master branch instead of tsuru_ansible/98450546_timeout_test

Cool copy and paste ;):

```
git checkout 98450546_timeout_test && \
gsed -i 's/98450546_timeout_test_platform/master/' spec/integration/integration_spec.rb && \
git commit -m "Update reference to Dockerfile to master branch" spec/integration/integration_spec.rb && \
git push
```
## How to test this PR

You only need to create a platform based on this file. Tsuru API must download the Dockerfile via HTTP, and for that we can use github itself. 

These commands will do the magic for you:

```
LAST_COMMIT=$(git rev-parse HEAD)
tsuru-admin platform-add delay-platform -d https://raw.githubusercontent.com/alphagov/tsuru-ansible/${LAST_COMMIT}/spec/test_platforms/delay_unit_platform/Dockerfile
```

You can deploy any git repo, even this repo itself. This will take > 30 seconds. If your nginx in front of the tsuru API has a timeout < 30, it will fail with a `504` error:

```
tsuru app-create delay-app delay-platform 
APP_REPO=$(tsuru app-info -a delay-app | sed -n 's/Repository: //p')

git push $APP_REPO
```

The application will remain in a 'starting' state all time because the `circusd` is missing and the platform is not really functional. That is OK, because the behaviour we want to implement is a delay while deployment.

To clean up:

```
tsuru app-remove -a delay-app -y 
tsuru-admin platform-remove delay-platform  -y
```
