### PR TITLE
[#99020160] Upgrade to Telegraf 0.1.4 and InfluxDB 0.9.1

### DIFF
--- a/influx_grafana.yml
+++ b/influx_grafana.yml
@@ -1,10 +1,12 @@
 - hosts: "{{ hosts_prefix }}-influx-grafana*"
   sudo: yes
   vars:
-    influxdb_version: latest
-  tasks: # The influxdb and telegraf packages disagree on ownership of /var/run/influxdb - Telegraf Issue #37
-    - name: Create /etc/default/telegraf to fix conflict between influxdb and telegraf packages
-      copy: dest=/etc/default/telegraf mode=0644 content="USER=influxdb\nGROUP=influxdb\n"
+    influxdb_version: 0.9.1
+    telegraf_version: 0.1.4
+  pre_tasks:
+    # FIXME: Remove when deployed everywhere.
+    - name: Remove custom /etc/default/telegraf hack
+      file: path=/etc/default/telegraf state=absent
   roles:
     - role: influxdb
     - role: telegraf


### PR DESCRIPTION
The package for Telegraf 0.1.2 (which our playbook defaults to) installs to
the same locations as InfluxDB and prevents one of them from starting
depending on which order they have been installed:
- https://github.com/influxdb/influxdb/blob/56d3addf563ec354d4220ef10c4733071781ede9/package.sh#L210
- https://github.com/influxdb/telegraf/blob/c4e5e743c43909ded0ca263a2c496c1996ed773b/package.sh#L182

This has been fixed in Telegraf >= 0.1.3 by installing to a separate directory:
- https://github.com/influxdb/telegraf/commit/120218f9c6b45bc909c5b9eaa6825d5ace6713be

We have to upgrade InfluxDB at the same time in order for it to rewrite its
own init script, because it's a post-install action. Both are patch upgrades
and don't look like they'll cause any problems:
- https://github.com/influxdb/telegraf/blob/v0.1.4/CHANGELOG.md
- https://github.com/influxdb/influxdb/blob/v0.9.1/CHANGELOG.md

Closely related to this, we can also remove our customisations that made
Telegraf run as the InfluxDB user, because they now have separate PID files.
This also has to be done at the same time as the upgrades because there
doesn't seem to be a nice abstraction to notify the service controlled by
the Ansible playbook.

Changing the version in the playbook's default variable didn't seem right
when we have a lot of other changes to make at the same time and we're
working towards pinning the versions that we use in our own repo. I may do
it independently.

Before:

```
ubuntu@ip-10-128-10-88:~$ ps ax | egrep 'influx|telegraf'
 1475 ?        Sl     0:01 /opt/influxdb/influxd -pidfile /var/run/influxdb/influxd.pid -config /etc/opt/influxdb/influxdb.conf
 2949 pts/0    S+     0:00 egrep --color=auto influx|telegraf
ubuntu@ip-10-128-10-88:~$ ls -al /etc/init.d/{influxdb,telegraf}
lrwxrwxrwx 1 root root 21 Jul 15 11:39 /etc/init.d/influxdb -> /opt/influxdb/init.sh
lrwxrwxrwx 1 root root 21 Jul 15 11:40 /etc/init.d/telegraf -> /opt/influxdb/init.sh
ubuntu@ip-10-128-10-88:~$ sudo service influxdb status
telegraf Process is not running [ FAILED ]
ubuntu@ip-10-128-10-88:~$ sudo service telegraf status
telegraf Process is not running [ FAILED ]
ubuntu@ip-10-128-10-88:~$ ls -al /var/run/{influxdb,telegraf}
ls: cannot access /var/run/telegraf: No such file or directory
/var/run/influxdb:
total 4
drwxr-xr-x  2 influxdb influxdb  60 Jul 15 11:39 .
drwxr-xr-x 19 root     root     680 Jul 15 12:10 ..
-rw-r--r--  1 influxdb influxdb   4 Jul 15 11:39 influxd.pid
```

After:

```
ubuntu@ip-10-128-10-88:~$ ps ax | egrep 'influx|telegraf'
 1475 ?        Sl     0:01 /opt/influxdb/influxd -pidfile /var/run/influxdb/influxd.pid -config /etc/opt/influxdb/influxdb.conf
 3334 ?        Sl     0:00 /opt/telegraf/telegraf -pidfile /var/run/telegraf/telegraf.pid -config /etc/opt/telegraf/telegraf.conf
 3508 pts/0    S+     0:00 egrep --color=auto influx|telegraf
ubuntu@ip-10-128-10-88:~$ ls -al /etc/init.d/{influxdb,telegraf}
lrwxrwxrwx 1 root root 21 Jul 15 12:13 /etc/init.d/influxdb -> /opt/influxdb/init.sh
lrwxrwxrwx 1 root root 21 Jul 15 12:13 /etc/init.d/telegraf -> /opt/telegraf/init.sh
ubuntu@ip-10-128-10-88:~$ sudo service influxdb status
influxd Process is running [ OK ]
ubuntu@ip-10-128-10-88:~$ sudo service telegraf status
telegraf Process is running [ OK ]
ubuntu@ip-10-128-10-88:~$ ls -al /var/run/{influxdb,telegraf}
/var/run/influxdb:
total 4
drwxr-xr-x  2 influxdb influxdb  60 Jul 15 11:39 .
drwxr-xr-x 20 root     root     700 Jul 15 12:13 ..
-rw-r--r--  1 influxdb influxdb   4 Jul 15 11:39 influxd.pid

/var/run/telegraf:
total 4
drwxr-xr-x  2 telegraf telegraf  60 Jul 15 12:13 .
drwxr-xr-x 20 root     root     700 Jul 15 12:13 ..
-rw-r--r--  1 telegraf telegraf   5 Jul 15 12:13 telegraf.pid
```
