### PR TITLE
[98450546] Add test to check timeout in nginx calling API while deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,15 @@ test: check-env-var check-target-api-host-var load-tsuru-creds
 	TSURU_PASS=${TSURU_PASS} \
 	bundle exec rake endtoend:all
 
+integration-test: check-env-var check-target-api-host-var load-tsuru-creds
+	@bundle install --path vendor/bundle --quiet
+	@SSL_CERT_FILE=$(shell python -m certifi) \
+	TARGET_API_HOST=${TARGET_API_HOST} \
+	TSURU_USER=${TSURU_USER} \
+	TSURU_PASS=${TSURU_PASS} \
+	bundle exec rake integration:all
+
+
 load-tsuru-creds:
 	$(eval TSURU_USER=$(shell \
 		ansible-vault view group_vars/all/secure | \
@@ -86,6 +95,10 @@ set-gce:
 	$(eval TARGET_API_HOST=${DEPLOY_ENV}-api.$(shell cat platform-gce.yml | awk -F \" '/domain_name:/ { print $$2 }'))
 test-aws: set-aws test
 test-gce: set-gce test
+
+integration-test-aws: set-aws integration-test
+integration-test-gce: set-gce integration-test
+
 
 diff-vault:
 	@(mkfifo -m 0600 ${VAULT_FIFO} && \

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,14 @@ namespace :endtoend do
   end
 end
 
+namespace :integration do
+  RSpec::Core::RakeTask.new(:all) do |t|
+    t.pattern = "spec/integration/*_spec.rb"
+    t.verbose = false
+  end
+end
+
+
 # Run all tasks
-task :default => [ "endtoend:all" ]
+task :default => [ "endtoend:all", "integration:all" ]
 

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -1,8 +1,7 @@
 require 'net/http'
 require 'open-uri'
 require 'openssl'
-require 'git_helper'
-require 'tsuru_helper'
+require 'workspace_helper'
 
 
 describe "TsuruEndToEnd" do
@@ -33,44 +32,19 @@ describe "TsuruEndToEnd" do
 
   context "deploying an application" do
     before(:all) do
-      @tsuru_home = Tempdir.new('tsuru-command')
-      @tsuru_command = TsuruCommandLine.new(
-        {'HOME' => @tsuru_home.path },
-        { :verbose => RSpec.configuration.verbose }
-      )
 
-      @tsuru_command.target_add("ci", @tsuru_api_url)
-      @tsuru_command.target_add("ci-insecure", @tsuru_api_url_insecure)
+      @workspace = WorkSpace.new()
+      @workspace.tsuru_command.target_add("ci", @tsuru_api_url)
+      @workspace.tsuru_command.target_add("ci-insecure", @tsuru_api_url_insecure)
 
       @tsuru_user = RSpec.configuration.tsuru_user || raise("You must set 'TSURU_USER' env var")
       @tsuru_pass = RSpec.configuration.tsuru_pass || raise("You must set 'TSURU_PASS' env var")
 
-      # Generate the ssh key and setup ssh
-      @ssh_id_rsa_path = File.join(@tsuru_home, '.ssh', 'id_rsa')
-      @ssh_id_rsa_pub_path = File.join(@tsuru_home, '.ssh', 'id_rsa.pub')
-      @ssh_config_file = File.join(@tsuru_home, '.ssh', 'config')
-      @ssh_wrapper_path = File.join(@tsuru_home, 'ssh-wrapper')
-      SshHelper.generate_key(@ssh_id_rsa_path)
-      SshHelper.write_config(
-        @ssh_config_file,
-        {
-        "StrictHostKeyChecking" => "no",
-        "IdentityFile" => @ssh_id_rsa_path,
-        }
-      )
-      SshHelper.write_ssh_wrapper(@ssh_wrapper_path, @ssh_config_file)
-
       # Clone the sample app and setup Git
       @sampleapp_name = 'sampleapp' + Time.now.to_i.to_s
-      @sampleapp_path = File.join(@tsuru_home, @sampleapp_name)
+      @sampleapp_path = File.join(@workspace.tsuru_home, @sampleapp_name)
 
-      @git_command = GitCommandLine.new(@sampleapp_path,
-        {
-          'HOME' => @tsuru_home.path,
-          'GIT_SSH' => @ssh_wrapper_path
-        },
-        { :verbose => RSpec.configuration.verbose }
-      )
+      @git_command = @workspace.create_git_command(@sampleapp_path)
       @git_command.clone("https://github.com/alphagov/flask-sqlalchemy-postgres-heroku-example.git")
 
       # Generate a random DB instance. postgresql truncates this name
@@ -81,67 +55,66 @@ describe "TsuruEndToEnd" do
     end
 
     after(:all) do
-      @tsuru_command.key_remove('rspec') # Remove previous state if needed
-      @tsuru_command.service_unbind(@sampleapp_db_instance, @sampleapp_name)
-      @tsuru_command.service_remove(@sampleapp_db_instance) # Remove previous state if needed
-      @tsuru_command.app_remove(@sampleapp_name) # Remove previous state if needed
-      @tsuru_home.rmrf
+      @workspace.tsuru_command.key_remove('rspec') # Remove previous state if needed
+      @workspace.tsuru_command.service_unbind(@sampleapp_db_instance, @sampleapp_name)
+      @workspace.tsuru_command.service_remove(@sampleapp_db_instance) # Remove previous state if needed
+      @workspace.tsuru_command.app_remove(@sampleapp_name) # Remove previous state if needed
+      @workspace.clean
     end
 
     it "should not be able to login via HTTP" do
-      @tsuru_command.target_set("ci-insecure")
-      @tsuru_command.login(@tsuru_user, @tsuru_pass)
-      expect(@tsuru_command.exit_status).not_to eql 0
+      @workspace.tsuru_command.target_set("ci-insecure")
+      @workspace.tsuru_command.login(@tsuru_user, @tsuru_pass)
+      expect(@workspace.tsuru_command.exit_status).not_to eql 0
     end
 
     it "should be able to login via HTTPS" do
-      @tsuru_command.target_set("ci")
-      @tsuru_command.login(@tsuru_user, @tsuru_pass)
-      expect(@tsuru_command.exit_status).to eql 0
+      @workspace.tsuru_command.target_set("ci")
+      @workspace.tsuru_command.login(@tsuru_user, @tsuru_pass)
+      expect(@workspace.tsuru_command.exit_status).to eql 0
     end
 
-
     it "should be able to add the ssh key" do
-      @tsuru_command.key_add('rspec', @ssh_id_rsa_pub_path)
-      expect(@tsuru_command.exit_status).to eql 0
-      expect(@tsuru_command.stdout).to match /Key .* successfully added!/
+      @workspace.tsuru_command.key_add('rspec', @workspace.ssh_id_rsa_pub_path)
+      expect(@workspace.tsuru_command.exit_status).to eql 0
+      expect(@workspace.tsuru_command.stdout).to match /Key .* successfully added!/
     end
 
     it "should be able to create an application" do
-      @tsuru_command.app_create(@sampleapp_name, 'python')
-      expect(@tsuru_command.exit_status).to eql 0
-      expect(@tsuru_command.stdout).to match /App .* has been created/
+      @workspace.tsuru_command.app_create(@sampleapp_name, 'python')
+      expect(@workspace.tsuru_command.exit_status).to eql 0
+      expect(@workspace.tsuru_command.stdout).to match /App .* has been created/
     end
 
     it "should be able to create a service" do
-      @tsuru_command.service_add('postgresql', @sampleapp_db_instance, 'shared')
-      expect(@tsuru_command.exit_status).to eql 0
-      expect(@tsuru_command.stdout).to match /Service successfully added/
+      @workspace.tsuru_command.service_add('postgresql', @sampleapp_db_instance, 'shared')
+      expect(@workspace.tsuru_command.exit_status).to eql 0
+      expect(@workspace.tsuru_command.stdout).to match /Service successfully added/
     end
 
     it "should be able to bind a service to an app" do
-      @tsuru_command.service_bind(@sampleapp_db_instance, @sampleapp_name)
-      expect(@tsuru_command.exit_status).to eql 0
-      expect(@tsuru_command.stdout).to match /Instance .* is now bound to the app .*/
+      @workspace.tsuru_command.service_bind(@sampleapp_db_instance, @sampleapp_name)
+      expect(@workspace.tsuru_command.exit_status).to eql 0
+      expect(@workspace.tsuru_command.stdout).to match /Instance .* is now bound to the app .*/
     end
 
     it "Should be able to push the application" do
-      git_url = @tsuru_command.get_app_repository(@sampleapp_name)
+      git_url = @workspace.tsuru_command.get_app_repository(@sampleapp_name)
       expect(git_url).not_to be_nil
       @git_command.push(git_url)
       expect(@git_command.exit_status).to eql 0
     end
 
     it "Should be able to connect to the applitation via HTTPS" do
-      sampleapp_address = @tsuru_command.get_app_address(@sampleapp_name)
+      sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
       response = URI.parse("https://#{sampleapp_address}/").open({ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
       expect(response.status).to eq(["200", "OK"])
     end
 
     it "Should get log output in 3 seconds" do
-      sampleapp_address = @tsuru_command.get_app_address(@sampleapp_name)
+      sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
       query = "my_special_query_" + Time.now.to_i.to_s
-      @tsuru_command.tail_app_logs(@sampleapp_name)
+      @workspace.tsuru_command.tail_app_logs(@sampleapp_name)
       sleep 1
       begin
         response = URI.parse("https://#{sampleapp_address}/" + query).open({ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
@@ -149,25 +122,25 @@ describe "TsuruEndToEnd" do
         ()
       end
       sleep 3
-      @tsuru_command.ctrl_c()
-      @tsuru_command.wait()
-      expect(@tsuru_command.stdout).to include query
+      @workspace.tsuru_command.ctrl_c()
+      @workspace.tsuru_command.wait()
+      expect(@workspace.tsuru_command.stdout).to include query
     end
 
     it "Should be able to connect to the applitation via HTTPS with a valid cert" do
       pending "We don't have a certificate for this :)"
-      sampleapp_address = @tsuru_command.get_app_address(@sampleapp_name)
+      sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
       response = URI.parse("https://#{sampleapp_address}/").open()
       expect(response.status).to eq(["200", "OK"])
     end
 
     it "should be able to unbind and bind a service to an app" do
       pending "There is already a bug filed: https://github.com/tsuru/postgres-api/issues/1"
-      @tsuru_command.service_unbind('sampleapptestdb', @sampleapp_name)
-      expect(@tsuru_command.exit_status).to eql 0
-      @tsuru_command.service_bind('sampleapptestdb', @sampleapp_name)
-      expect(@tsuru_command.exit_status).to eql 0
-      expect(@tsuru_command.stdout).to match /Instance .* is now bound to the app .*/
+      @workspace.tsuru_command.service_unbind('sampleapptestdb', @sampleapp_name)
+      expect(@workspace.tsuru_command.exit_status).to eql 0
+      @workspace.tsuru_command.service_bind('sampleapptestdb', @sampleapp_name)
+      expect(@workspace.tsuru_command.exit_status).to eql 0
+      expect(@workspace.tsuru_command.stdout).to match /Instance .* is now bound to the app .*/
     end
 
   end

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -5,11 +5,11 @@ require 'workspace_helper'
 
 
 describe "TsuruEndToEnd" do
-  before(:all) {
+  before(:all) do
     @tsuru_api_host = RSpec.configuration.target_api_host || raise("You must set 'TARGET_API_HOST' env var")
     @tsuru_api_url = "https://#{@tsuru_api_host}"
     @tsuru_api_url_insecure = "http://#{@tsuru_api_host}:8080"
-  }
+  end
 
   describe "healthchecks" do
     let(:healthcheck_response) {

--- a/spec/git_helper.rb
+++ b/spec/git_helper.rb
@@ -44,6 +44,18 @@ class GitCommandLine < CommandLineHelper
     execute_helper('git', 'clone', url, @path)
   end
 
+  def init()
+    execute_helper('git', 'init', { :chdir => @path })
+  end
+
+  def add(*cmd)
+    execute_helper('git', 'add', *cmd, { :chdir => @path })
+  end
+
+  def commit(msg)
+    execute_helper('git', 'commit', '-m', msg, { :chdir => @path })
+  end
+
   def push(remote = 'origin', local_branch = 'master', remote_branch = 'master')
     execute_helper('git', 'push', remote, "#{local_branch}:#{remote_branch}", { :chdir => @path })
   end

--- a/spec/git_helper.rb
+++ b/spec/git_helper.rb
@@ -48,6 +48,11 @@ class GitCommandLine < CommandLineHelper
     execute_helper('git', 'init', { :chdir => @path })
   end
 
+  def config_name_mail(name, mail)
+    execute_helper('git', 'config', 'user.name', name, { :chdir => @path })
+    execute_helper('git', 'config', 'user.email', mail, { :chdir => @path })
+  end
+
   def add(*cmd)
     execute_helper('git', 'add', *cmd, { :chdir => @path })
   end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -59,7 +59,7 @@ describe "Integration" do
     end
 
     it "should be able to deploy a platform with a delay in tsuru_unit_agent" do
-      @workspace.tsuru_command.platform_add(@sampleplatform_name, 'https://raw.githubusercontent.com/alphagov/tsuru-ansible/98450546_timeout_test_platform/spec/test_platforms/delay_unit_platform/Dockerfile')
+      @workspace.tsuru_command.platform_add(@sampleplatform_name, 'https://raw.githubusercontent.com/alphagov/tsuru-ansible/master/spec/test_platforms/delay_unit_platform/Dockerfile')
       expect(@workspace.tsuru_command.exit_status).to eql 0
       expect(@workspace.tsuru_command.stdout).to match /Platform successfully added/
     end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -28,6 +28,7 @@ describe "Integration" do
 
       @git_command = @workspace.create_git_command(@sampleapp_path)
       @git_command.init()
+      @git_command.config_name_mail("John Smith", "john.smith@example.com")
       @git_command.add("file.txt")
       @git_command.commit("a commit")
     end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -1,0 +1,84 @@
+require 'net/http'
+require 'open-uri'
+require 'openssl'
+require 'workspace_helper'
+
+
+describe "Integration" do
+  before(:all) {
+    @workspace = WorkSpace.new()
+    @tsuru_api_host = RSpec.configuration.target_api_host || raise("You must set 'TARGET_API_HOST' env var")
+    @tsuru_user = RSpec.configuration.tsuru_user || raise("You must set 'TSURU_USER' env var")
+    @tsuru_pass = RSpec.configuration.tsuru_pass || raise("You must set 'TSURU_PASS' env var")
+    @tsuru_api_url = "https://#{@tsuru_api_host}"
+    @workspace.do_login(@tsuru_api_url, @tsuru_user, @tsuru_pass)
+  }
+  after(:all) do
+    @workspace.clean
+  end
+
+  context "checking timeout while deploying" do
+    before(:all) do
+      @sampleapp_name = 'sampleapp' + Time.now.to_i.to_s
+      @sampleapp_path = File.join(@workspace.tsuru_home, @sampleapp_name)
+      FileUtils.mkdir(@sampleapp_path)
+      FileUtils.touch(File.join(@sampleapp_path, 'file.txt'))
+
+      @sampleplatform_name = 'sampleplatform' + Time.now.to_i.to_s
+
+      @git_command = @workspace.create_git_command(@sampleapp_path)
+      @git_command.init()
+      @git_command.add("file.txt")
+      @git_command.commit("a commit")
+    end
+
+    after(:all) do
+      # Remove the application. Wait for the unlock if needed
+      retries=5
+      begin
+        @workspace.tsuru_command.app_remove(@sampleapp_name)
+        expect(@workspace.tsuru_command.stderr).to_not match /App locked by/
+      rescue RSpec::Expectations::ExpectationNotMetError
+        sleep 5
+        retry if (retries -= 1) > 0
+        @workspace.tsuru_command.app_unlock(@sampleapp_name)
+        @workspace.tsuru_command.app_remove(@sampleapp_name)
+      end
+      # Remove the platform
+      retries=5
+      begin
+        @workspace.tsuru_command.platform_remove(@sampleplatform_name)
+        expect(@workspace.tsuru_command.stderr).to_not match /Platform has apps/
+      rescue RSpec::Expectations::ExpectationNotMetError
+        # Wait to the app to get deleted, we found that tsuru
+        # takes some seconds to actually get the application removed.
+        sleep 5
+        retry if (retries -= 1) > 0
+      end
+    end
+
+    it "should be able to deploy a platform with a delay in tsuru_unit_agent" do
+      @workspace.tsuru_command.platform_add(@sampleplatform_name, 'https://raw.githubusercontent.com/alphagov/tsuru-ansible/98450546_timeout_test_platform/spec/test_platforms/delay_unit_platform/Dockerfile')
+      expect(@workspace.tsuru_command.exit_status).to eql 0
+      expect(@workspace.tsuru_command.stdout).to match /Platform successfully added/
+    end
+
+    it "should be able to create an application using the delay platform" do
+      @workspace.tsuru_command.app_create(@sampleapp_name, @sampleplatform_name)
+      expect(@workspace.tsuru_command.exit_status).to eql 0
+      expect(@workspace.tsuru_command.stdout).to match /App .* has been created/
+    end
+
+    it "Should be able to push the application and not timeout" do
+      git_url = @workspace.tsuru_command.get_app_repository(@sampleapp_name)
+      expect(git_url).not_to be_nil
+      @git_command.push(git_url)
+      expect(@git_command.exit_status).to eql 0
+    end
+
+  end
+end
+
+
+
+

--- a/spec/test_platforms/README.md
+++ b/spec/test_platforms/README.md
@@ -1,0 +1,12 @@
+Custom platforms for tsuru debuging and testing
+===============================================
+
+This repository contains some custom platforms for testing and debuging
+[tsuru](http://tsuru.io).
+
+Delay unit platform
+-------------------
+
+This is a fake platforms that does `sleep` when calling the `tsuru_unit_agent`
+to test timeouts.
+

--- a/spec/test_platforms/delay_unit_platform/Dockerfile
+++ b/spec/test_platforms/delay_unit_platform/Dockerfile
@@ -1,0 +1,7 @@
+from	ubuntu:14.04
+# Create a fake tsuru_unit_agent
+run echo "#!/bin/sh\nsleep 31" > /usr/local/bin/tsuru_unit_agent
+run	chmod +x /usr/local/bin/tsuru_unit_agent
+# Add the ubuntu user
+run useradd -m ubuntu -s /bin/bash
+run echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/spec/tsuru_helper.rb
+++ b/spec/tsuru_helper.rb
@@ -58,6 +58,10 @@ class TsuruCommandLine < CommandLineHelper
     execute_helper('tsuru', 'app-remove', '-a', app_name, '-y')
   end
 
+  def app_unlock(app_name)
+    execute_helper('tsuru-admin', 'app-unlock', '-a', app_name, '-y')
+  end
+
   def key_add(ssh_key_name, ssh_key_path)
     execute_helper('tsuru', 'key-add', ssh_key_name, ssh_key_path)
   end
@@ -80,6 +84,14 @@ class TsuruCommandLine < CommandLineHelper
 
   def service_unbind(service_instance_name, app_name)
     execute_helper('tsuru', 'service-unbind', service_instance_name, '-a', app_name)
+  end
+
+  def platform_add(platform_name, dockerfile)
+    execute_helper('tsuru-admin', 'platform-add', platform_name, '-d', dockerfile)
+  end
+
+  def platform_remove(platform_name)
+    execute_helper('tsuru-admin', 'platform-remove', platform_name, '-y')
   end
 
   def get_app_repository(app_name)

--- a/spec/workspace_helper.rb
+++ b/spec/workspace_helper.rb
@@ -1,0 +1,45 @@
+require 'git_helper'
+require 'tsuru_helper'
+
+class WorkSpace
+  attr_accessor :tsuru_home, :tsuru_user, :tsuru_pass, :ssh_id_rsa_pub_path
+  attr_accessor :tsuru_command
+
+  def clean()
+      @tsuru_home.rmrf
+  end
+
+  def create_git_command(path)
+      @git_command = GitCommandLine.new(path,
+        {
+          'HOME' => @tsuru_home.path,
+          'GIT_SSH' => @ssh_wrapper_path
+        },
+        { :verbose => RSpec.configuration.verbose }
+      )
+  end
+
+  def initialize()
+      @tsuru_home = Tempdir.new('tsuru-command')
+      @tsuru_command = TsuruCommandLine.new(
+        { 'HOME' => @tsuru_home.path },
+        { :verbose => RSpec.configuration.verbose }
+      )
+
+      # Generate the ssh key and setup ssh
+      @ssh_id_rsa_path = File.join(@tsuru_home, '.ssh', 'id_rsa')
+      @ssh_id_rsa_pub_path = File.join(@tsuru_home, '.ssh', 'id_rsa.pub')
+      @ssh_config_file = File.join(@tsuru_home, '.ssh', 'config')
+      @ssh_wrapper_path = File.join(@tsuru_home, 'ssh-wrapper')
+      SshHelper.generate_key(@ssh_id_rsa_path)
+      SshHelper.write_config(
+        @ssh_config_file,
+        {
+        "StrictHostKeyChecking" => "no",
+        "IdentityFile" => @ssh_id_rsa_path,
+        }
+      )
+      SshHelper.write_ssh_wrapper(@ssh_wrapper_path, @ssh_config_file)
+
+  end
+end


### PR DESCRIPTION
Refers to: [98450546 BUG: 504 timeout when deploying app](https://www.pivotaltracker.com/n/projects/1275640/stories/98450546)
## Context

We experienced a bug while deploying applications, we sometimes get a `504 Gateway Time-out`. Also manifests as a drop connection while deploying.

[After investigating the issue](https://www.pivotaltracker.com/n/projects/1275640/stories/98450546), we conclude that this is caused due a [low timeout (`proxy_read_timeout 15s;`)](https://github.com/alphagov/tsuru-ansible/blob/384afd6a52e21de831b56c156fb713efb918fc42/ssl_proxy_vars.yml#L13) in the [nginx used to terminate SSL](https://github.com/alphagov/tsuru-ansible/pull/74) in front of the API. 

Tsuru actually implements some heartbeats to prevent timeouts:
- [30 seconds from API while deploying.](https://github.com/tsuru/tsuru/blob/2001ef136b025f3d6f7a52e9bea94e070de1b3d6/api/deploy.go#L75)
- [5 seconds while executing commands by `tsuru_unit_agent`](https://github.com/tsuru/tsuru-unit-agent/blob/master/tsuru_unit_agent/heartbeat.py#L13)

With these timeouts, changing the timeout in nginx to a value > 30 seconds will avoid the problem, [as we did in this PR](https://github.com/alphagov/tsuru-ansible/pull/107)

But we want to test it to avoid regressions.
## How this PR should be reviewed

We want to implement a test to detect any regression. For that this story must be reviewed in this context:
- given a platform that simulates a delay while deploying > 30 seconds, [implemented in this other PR](https://github.com/alphagov/tsuru-ansible/pull/121)
- I want to have a test that adds this platform and tries to deploy an application
- If the configuration is OK, the test should pass (no timeout)
- I want to have a way to run this tests, separated from the endtoend & smoke tests
## How to test this PR

To run the tests, use the makefile tasks provided:

```
make integration-test-gce DEPLOY_ENV=<envname> VERBOSE=true
```

With the current configuration the test should pass. To force it to fail, we need to [add back the timeout in nginx](https://github.com/alphagov/tsuru-ansible/pull/107). 

For that (copy&paste below):
1. SSH to the tsuru API servers
2. Add `proxy_read_timeout 15s;` to the file `/etc/nginx/sites-enabled/ssl_reverse_proxy.conf`
3. Restart nginx: `service nginx restart` 

Or use this oneliner (adapt for your environment):

```
ansible all -i gce.py -a 'sudo sed -i "s/proxy_connect_timeout 15s;/proxy_connect_timeout 15s;\n\tproxy_read_timeout 15s;/" /etc/nginx/sites-enabled/ssl_reverse_proxy.conf' -l '~^hector070715-tsuru-api-+' 
```

Then run the tests again.

To revert this change, run ansible again or:

```
ansible all -i gce.py -a 'sudo sed -i "/proxy_read_timeout 15s;/d" /etc/nginx/sites-enabled/ssl_reverse_proxy.conf' -l '~^hector070715-tsuru-api-+'
ansible all -i gce.py -a 'sudo service nginx restart' -l '~^hector070715-tsuru-api-+'
```
## Dependencies

This PR is related [to the PR to add the platform Dockerfile](https://github.com/alphagov/tsuru-ansible/pull/121). If the last gets merge, we must update [this file](https://github.com/alphagov/tsuru-ansible/blob/71e13d867b5d8e1c84b88cb8ae0b89e44afa127f/spec/integration/integration_spec.rb#L61) to point to the master branch.
## Who can review this?

Anybody in the team except me, @keymon, or @mtekel 
