### PR TITLE
[#99020160] Fix/remove 2nd telegraf install

### DIFF
--- a/influx_grafana.yml
+++ b/influx_grafana.yml
@@ -2,14 +2,8 @@
   sudo: yes
   vars:
     influxdb_version: 0.9.1
-    telegraf_version: 0.1.4
-  pre_tasks:
-    # FIXME: Remove when deployed everywhere.
-    - name: Remove custom /etc/default/telegraf hack
-      file: path=/etc/default/telegraf state=absent
   roles:
     - role: influxdb
-    - role: telegraf
     - role: Stouts.grafana
   post_tasks:
     - name: Copy grafana API control script
@@ -19,5 +13,8 @@
 
 - hosts: "{{ hosts_prefix }}-*"
   sudo: yes
+  tags: telegraf
+  vars:
+    telegraf_version: 0.1.4
   roles:
     - telegraf


### PR DESCRIPTION
I forgot to provide a version to the 2nd call to the telegraf playbook which
caused it to fail with:

```
failed: [10.128.10.125] => {"failed": true}
msg: A later version is already installed
```

Fix this by
- removing the first call to the playbook, which is no longer needed now
  that we've fixed the incompatibility between Telegraf/InfluxDB - we can
  rely on the entry that matches all hosts
- passing a version to the Telegraf playbook that gets installed to all
  hosts
