### PR TITLE
[#99020160] Bump telegraf playbook to v0.1.0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -32,7 +32,7 @@
   version: v0.0.1
 - name: telegraf
   src: https://github.com/alphagov/ansible-playbook-telegraf.git
-  version: v0.0.1
+  version: v0.1.0
 
 # GDS Forked, pull-request sent upstream awaiting merge.
 - name: bennojoy.redis


### PR DESCRIPTION
Which changes:
- the default version of Telegraf from 0.1.2 to 0.1.4 (doesn't affect us
  because we are already overriding it with variables)
- the path of the config file to match the new install directory and makes
  Telegraf correctly report metrics again

https://github.com/alphagov/ansible-playbook-telegraf/compare/v0.0.1...v0.1.0
