### PR TITLE
[#95168192] Unify AWS and GCE node names 

### DIFF
--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -8,7 +8,7 @@ ssl_key: "{{ aws_ssl_key }}"
 redis_host_name: "{{ hosts_prefix }}-tsuru-db"
 redis_host: "{{ hostvars[groups[redis_host_name][0]][ip_field_name] }}"
 
-tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api"
+tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api-0"
 tsuru_api_host: "{{ hostvars[groups[tsuru_api_host_name][0]][ip_field_name] }}"
 tsuru_api_internal_lb: "{{ deploy_env }}-api-int.{{ domain_name }}"
 tsuru_api_external_lb: "{{ deploy_env }}-api.{{ domain_name }}"

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -16,20 +16,21 @@
     - name: Install httplib2 for Ansible uri module
       apt: name=python-httplib2 state=present
 
+# Run these tasks explicitly on 1st API server as the rest of playbooks (post install) expect it
+- hosts: "{{ hosts_prefix }}-tsuru-api*[0]"
+  sudo: yes
+  tasks:
     - name: add admin team
-      run_once: true
       shell: >
         mongo tsuru --eval 'db.teams.update({_id: "admin"}, {_id: "admin"}, {upsert: true})';
       delegate_to: "{{ mongodb_host }}"
 
     - name: add admin user to admin team
-      run_once: true
       shell: >
         mongo tsuru --eval "db.teams.update({_id: 'admin'}, {\$addToSet: {users: '{{admin_user}}'}})";
       delegate_to: "{{ mongodb_host }}"
 
     - name: add admin user
-      run_once: true
       uri:
         method=POST body_format=json
         body="{\"email\":\"{{ admin_user }}\",\"password\":\"{{ admin_password }}\"}"
@@ -37,7 +38,6 @@
         status_code=201,409
 
     - name: login with the admin user
-      run_once: true
       uri:
         method=POST body_format=json
         body="{\"password\":\"{{ admin_password }}\"}"
@@ -46,5 +46,4 @@
       register: login_response
 
     - name: write admin token
-      run_once: true
       copy: dest=~/.tsuru_token mode=0600 content="{{ (login_response.content|from_json).token }}"


### PR DESCRIPTION
There is no reason why we should have different node names between AWS and GCE. Having same node names makes our ansible and terraform configuration more clear and straightforward.

Depends on https://github.com/alphagov/tsuru-terraform/pull/85
