### PR TITLE
[#95512034] Faster docker node deployment

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -36,11 +36,13 @@
       service: name=gandalf-server state=restarted
 
 - hosts: "{{ hosts_prefix }}-tsuru-docker*"
-  serial: 1
   sudo: yes
   roles:
     - docker_server
 
+- hosts: "{{ hosts_prefix }}-tsuru-docker*"
+  serial: 1
+  sudo: yes
   post_tasks:
     - name: Register node.
       shell: >

--- a/site.yml
+++ b/site.yml
@@ -5,11 +5,6 @@
   sudo: yes
   roles:
     - bennojoy.redis
-
-- hosts: "{{ hosts_prefix }}-tsuru-db"
-  sudo: yes
-  sudo_user: root
-  roles:
     - greendayonfire.mongodb
 
 # tsuru core components.


### PR DESCRIPTION
Do the main and slow docker server installation in parallel on all servers. Then run the concurrent-ssh-bug affected actions in serial, node-by-node. This speeds up deployment of the platform considerably.
