### PR TITLE
[#98453390] Remove internal LB

### DIFF
--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -21,7 +21,6 @@ mongodb_conf_bind_ip: 0.0.0.0
 mongodb_port: 27017
 
 tsuru_api_external_url: https://{{ tsuru_api_external_lb }}:443
-tsuru_api_internal_url: https://{{ tsuru_api_internal_lb }}:443
 
 # WAL-E Configuration
 enable_postgres_log_shipping: true

--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -11,7 +11,6 @@ redis_host: "{{ hostvars[groups[redis_host_name][0]][ip_field_name] }}"
 
 tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api-0"
 tsuru_api_host: "{{ hostvars[groups[tsuru_api_host_name][0]][ip_field_name] }}"
-tsuru_api_internal_lb: "{{ deploy_env }}-api-int.{{ domain_name }}"
 tsuru_api_external_lb: "{{ deploy_env }}-api.{{ domain_name }}"
 
 gandalf_host_name: "{{ hosts_prefix }}-tsuru-gandalf"

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -11,7 +11,6 @@ redis_host: "{{ hostvars[redis_host_name][ip_field_name] }}"
 
 tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api-0"
 tsuru_api_host: "{{ hostvars[tsuru_api_host_name][ip_field_name] }}"
-tsuru_api_internal_lb: "{{ hosts_prefix }}-api.{{ domain_name }}"
 tsuru_api_external_lb: "{{ hosts_prefix }}-api.{{ domain_name }}"
 
 gandalf_host_name: "{{ hosts_prefix }}-tsuru-gandalf"

--- a/site.yml
+++ b/site.yml
@@ -12,7 +12,7 @@
   sudo: yes
   roles:
     - role: gandalf
-      tsuru_api_endpoint: "{{ tsuru_api_internal_url }}"
+      tsuru_api_endpoint: "{{ tsuru_api_external_url }}"
 
 - include: tsuru_api.yml
 


### PR DESCRIPTION
Remove internal LB from AWS. Internal LB on aws is only being used by Gandalf to connect to the tsuru API for callbacks. It seems internal LB was left as leftover from time when we had separate SSL proxies and routers/API and LBs between them. Given that Gandalf can talk to the Tsuru API directly on the external URL (and do so securely - via SSL & limited by firewall to specific gandalf IP), there's no need to keep running internal LB anymore. On GCE, there's no internal LB. There is a [story](https://www.pivotaltracker.com/n/projects/1275640/stories/93542284) to add it, but it seems that story is from time when we had SSL proxies and having parity between AWS and GCE meant adding internal LB to GCE.
### Testing:
1. Apply [terraform PR](https://github.com/alphagov/tsuru-terraform/pull/88)
2. Apply this PR
3. run smoketests `make test-aws DEPLOY_ENV=...` and `make test-gce DEPLOY_ENV=...`
