### PR TITLE
[#98640854] Add logic to handle locked app in test after hook

### DIFF
--- a/spec/command_line_helper.rb
+++ b/spec/command_line_helper.rb
@@ -12,7 +12,15 @@ class CommandLineHelper
   def wait()
     @tout.join if @tout
     @terr.join if @terr
-    @exit_status = @wait_thread.value.to_i >> 8 if @wait_thread
+    if @wait_thread
+      # Return code can be the the signal number if killed with signal
+      # or exit value shifted 8 bits if exited normally
+      if @wait_thread.value.signaled?
+        @exit_status = @wait_thread.value.to_i + 128
+      else
+        @exit_status = @wait_thread.value.to_i >> 8
+      end
+    end
     self
   end
 

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -60,7 +60,7 @@ describe "TsuruEndToEnd" do
       @workspace.tsuru_command.service_unbind(@sampleapp_db_instance, @sampleapp_name)
       @workspace.tsuru_command.service_remove(@sampleapp_db_instance)
       # Remove the application. Wait for the unlock if needed
-      retries=5
+      retries=25
       begin
         @workspace.tsuru_command.app_remove(@sampleapp_name)
         expect(@workspace.tsuru_command.stderr).to_not match /App locked by/

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -70,10 +70,10 @@ describe "TsuruEndToEnd" do
       end
       retries=25
       begin
+        sleep 1
         @workspace.tsuru_command.service_remove(@sampleapp_db_instance)
         expect(@workspace.tsuru_command.stderr).to_not match /This service instance is bound to at least one app/
       rescue RSpec::Expectations::ExpectationNotMetError
-        sleep 1
         retry if (retries -= 1) > 0
       end
       @workspace.clean

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -56,10 +56,8 @@ describe "TsuruEndToEnd" do
 
     after(:all) do
       # Remove previous state if needed.
-      @workspace.tsuru_command.key_remove('rspec') # Remove previous state if needed
-      @workspace.tsuru_command.service_unbind(@sampleapp_db_instance, @sampleapp_name)
-      @workspace.tsuru_command.service_remove(@sampleapp_db_instance)
-      # Remove the application. Wait for the unlock if needed
+      @workspace.tsuru_command.key_remove('rspec')
+      # Remove the app. Wait for the unlock if needed
       retries=25
       begin
         @workspace.tsuru_command.app_remove(@sampleapp_name)
@@ -70,6 +68,7 @@ describe "TsuruEndToEnd" do
         @workspace.tsuru_command.app_unlock(@sampleapp_name)
         @workspace.tsuru_command.app_remove(@sampleapp_name)
       end
+      @workspace.tsuru_command.service_remove(@sampleapp_db_instance)
       @workspace.clean
     end
 

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -115,20 +115,20 @@ describe "TsuruEndToEnd" do
       expect(@workspace.tsuru_command.stdout).to match /Instance .* is now bound to the app .*/
     end
 
-    it "Should be able to push the application" do
+    it "should be able to push the application" do
       git_url = @workspace.tsuru_command.get_app_repository(@sampleapp_name)
       expect(git_url).not_to be_nil
       @git_command.push(git_url)
       expect(@git_command.exit_status).to eql 0
     end
 
-    it "Should be able to connect to the applitation via HTTPS" do
+    it "should be able to connect to the applitation via HTTPS" do
       sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
       response = URI.parse("https://#{sampleapp_address}/").open({ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
       expect(response.status).to eq(["200", "OK"])
     end
 
-    it "Should get log output in 3 seconds" do
+    it "should get log output in 3 seconds" do
       sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
       query = "my_special_query_" + Time.now.to_i.to_s
       @workspace.tsuru_command.tail_app_logs(@sampleapp_name)
@@ -144,7 +144,7 @@ describe "TsuruEndToEnd" do
       expect(@workspace.tsuru_command.stdout).to include query
     end
 
-    it "Should be able to connect to the applitation via HTTPS with a valid cert" do
+    it "should be able to connect to the applitation via HTTPS with a valid cert" do
       pending "We don't have a certificate for this :)"
       sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
       response = URI.parse("https://#{sampleapp_address}/").open()

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -68,7 +68,14 @@ describe "TsuruEndToEnd" do
         @workspace.tsuru_command.app_unlock(@sampleapp_name)
         @workspace.tsuru_command.app_remove(@sampleapp_name)
       end
-      @workspace.tsuru_command.service_remove(@sampleapp_db_instance)
+      retries=25
+      begin
+        @workspace.tsuru_command.service_remove(@sampleapp_db_instance)
+        expect(@workspace.tsuru_command.stderr).to_not match /This service instance is bound to at least one app/
+      rescue RSpec::Expectations::ExpectationNotMetError
+        sleep 1
+        retry if (retries -= 1) > 0
+      end
       @workspace.clean
     end
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -35,7 +35,7 @@ describe "Integration" do
 
     after(:all) do
       # Remove the application. Wait for the unlock if needed
-      retries=5
+      retries=25
       begin
         @workspace.tsuru_command.app_remove(@sampleapp_name)
         expect(@workspace.tsuru_command.stderr).to_not match /App locked by/


### PR DESCRIPTION
Reference: [Docker nodes in demo environment uncontactable](https://www.pivotaltracker.com/n/projects/1275640/stories/98640854)
### Context

We found out that sometimes the smoke tests don't clean properly the apps, leaving them running in the platform. 

After investigating, we found that when running the test the application can be potentially locked in the
tsuru API server, for instance because the git push timeout or was disconnected. When this happens, the `after` hook will fail cleaning up the application. 

This code adds logic which will wait 5 seconds and retry if it fails deleting it because it is locked, giving a change to finish the running task. After 5 retries, it will force an unlock to delete it.
### How to review this PR?

You should be able to run the tests (check README.md):

```
make test-gce DEPLOY_ENV=<yourenv>
make test-aws DEPLOY_ENV=<yourenv>
```

and no applications are left behind:

```
$ tsuru app-list | grep sampleapp
$
```

If you want to trigger the retry when lock logic, you can kill the git command doing the push with: `killall git`
### Who can review this?

Anybody but @keymon or @jimconner 
