### PR TITLE
[#99121602] Add elasticsearch service

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,0 +1,19 @@
+---
+
+- hosts: "{{ hosts_prefix }}-tsuru-elasticsearch"
+  sudo: yes
+  sudo_user: root
+  tasks:
+    - name: Elasticsearch | Install java
+      apt: name=openjdk-7-jre-headless state=present update_cache=yes
+    - name: Elasticsearch | Download ES 1.6.0
+      get_url:
+        url: https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.0.deb
+        dest: /tmp/elasticsearch-1.6.0.deb
+    - name: Elasticsearch | Install ES 1.6.0
+      apt:
+        deb: /tmp/elasticsearch-1.6.0.deb
+    - name: Elasticsearch | Start the service
+      service:
+        name: elasticsearch
+        state: started

--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -36,3 +36,6 @@ postgresql_archive_command: >
   {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} wal-push %p
 
 postgres_master_host: "{{ deploy_env }}-postgres-master.{{ domain_name }}"
+
+elasticsearch_host_name: "{{ hosts_prefix }}-tsuru-elasticsearch"
+elasticsearch_url: "{{ deploy_env }}-elasticsearchapi.{{ domain_name }}"

--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -38,4 +38,4 @@ postgresql_archive_command: >
 postgres_master_host: "{{ deploy_env }}-postgres-master.{{ domain_name }}"
 
 elasticsearch_host_name: "{{ hosts_prefix }}-tsuru-elasticsearch"
-elasticsearch_url: "{{ deploy_env }}-elasticsearchapi.{{ domain_name }}"
+elasticsearch_api: "{{ deploy_env }}-elasticsearchapi.{{ domain_name }}"

--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -20,6 +20,8 @@ gandalf_host_internal: "{{ hostvars[groups[gandalf_host_name][0]][ip_field_name]
 mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
 mongodb_host: "{{ hostvars[groups[mongodb_host_name][0]][ip_field_name] }}"
 
+elasticsearch_host: "{{ hostvars[groups[elasticsearch_host_name][0]][ip_field_name] }}"
+
 influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"
 influxdb_url: "http://{{ hostvars[groups[influxdb_host_name][0]][ip_field_name] }}:8086"
 

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -23,6 +23,8 @@ mongodb_host: "{{ hostvars[mongodb_host_name][ip_field_name] }}"
 influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"
 influxdb_url: "http://{{ hostvars[influxdb_host_name][ip_field_name] }}:8086"
 
+elasticsearch_host: "{{ hostvars[elasticsearch_host_name][ip_field_name] }}"
+
 # WAL-E Configuration
 wal_e_aws_instance_profile: false
 wal_e_aws_access_key: "{{ gs_access_key }}"

--- a/post-install.yml
+++ b/post-install.yml
@@ -178,6 +178,66 @@
         crane create ~/postgresapi.yml
       when: "not 'postgresql' in service_list.stdout"
 
+    # Elasticsearch
+
+    - name: Post Install Tasks | Tsuru app-create elasticsearchapi
+      ignore_errors: yes
+      shell: >
+        tsuru app-create elasticsearchapi python -t admin
+      when: "not 'elasticsearchapi' in tsuru_apps.stdout"
+
+    - name: Post Install Tasks | Get env variables of elasticsearchapi
+      shell: >
+        tsuru env-get -a elasticsearchapi
+      register: elasticsearchapi_env
+
+    - name: Post Install Tasks | Tsuru set environment variables for elasticsearchapi
+      shell: >
+        tsuru env-set -a elasticsearchapi ELASTICSEARCH_HOST={{ elasticsearch_host }};
+      when: "not \"{{ elasticsearch_host }}\" in elasticsearchapi_env.stdout"
+
+    - name: Post Install Tasks | Git pull elasticsearchapi
+      git:
+        repo: https://github.com/alphagov/elastic-search-api.git
+        dest: /tmp/elasticsearchapi
+        version: "717c1faa36c926ec8715fc7245ad8bde0f8a30f6"
+
+    - name: Post Install Tasks | Get gandalf repo for elasticsearchapi
+      shell: >
+        tsuru app-info -a elasticsearchapi | grep -o 'git@.\+'
+      register: elasticsearchapi_git_remote
+
+    - name: Post Install Tasks | Git push elasticsearchapi to gandalf
+      shell: >
+        git push {{ elasticsearchapi_git_remote.stdout }} master
+      args:
+        chdir: /tmp/elasticsearchapi
+
+    - name: Post Install Tasks | Tsuru app-info elasticsearchapi
+      shell: >
+        tsuru app-info -a elasticsearchapi
+      register: elasticsearchapi_app_info
+
+    - name: Post Install Tasks | Add <deploy_env>-elasticsearchapi.<domain_name> cname to elasticsearchapi app
+      shell: >
+        tsuru cname-add {{ elasticsearch_url }} -a elasticsearchapi
+      when: "not \"{{ elasticsearch_url }}\" in elasticsearchapi_app_info.stdout"
+
+    - name: Post Install Tasks | Generate elasticsearchapi.yml
+      copy:
+        content: |
+          id: elasticsearch
+          username: admin
+          password: password
+          endpoint:
+            production: https://{{ elasticsearch_url }}
+        dest: ~/elasticsearchapi.yml
+
+    - name: Post Install Tasks | Register elasticsearch service
+      shell: >
+        crane create ~/elasticsearchapi.yml
+      when: "not 'elasticsearch' in service_list.stdout"
+
     - debug: var=dashboard_app_info.stdout_lines
     - debug: var=postgresapi_app_info.stdout_lines
-
+    - debug: var=elasticsearchapi_app_info.stdout_lines

--- a/post-install.yml
+++ b/post-install.yml
@@ -54,17 +54,14 @@
         tsuru platform-list | awk {'print $2'}
       register: tsuru_platforms
     - name: Post Install Tasks | Tsuru platform add python
-      ignore_errors: no
       shell: >
         tsuru-admin platform-add python -d https://raw.github.com/tsuru/basebuilder/master/python/Dockerfile
       when: "not 'python' in tsuru_platforms.stdout"
     - name: Post Install Tasks | Tsuru platform add java
-      ignore_errors: no
       shell: >
         tsuru-admin platform-add java -d https://raw.github.com/tsuru/basebuilder/master/java/Dockerfile
       when: "not 'java' in tsuru_platforms.stdout"
     - name: Post Install Tasks | Tsuru platform add static
-      ignore_errors: no
       shell: >
         tsuru-admin platform-add static -d https://raw.github.com/tsuru/basebuilder/master/static/Dockerfile
       when: "not 'static' in tsuru_platforms.stdout"
@@ -83,7 +80,6 @@
         tsuru app-list
       register: tsuru_apps
     - name: Post Install Tasks | Tsuru app-create dashboard
-      ignore_errors: yes
       shell: >
         tsuru app-create dashboard python -t admin
       when: "not 'dashboard' in tsuru_apps.stdout"
@@ -111,7 +107,6 @@
     # Adding postgresapi app
 
     - name: Post Install Tasks | Tsuru app-create postgresapi
-      ignore_errors: yes
       shell: >
         tsuru app-create postgresapi python -t admin
       when: "not 'postgresapi' in tsuru_apps.stdout"
@@ -183,7 +178,6 @@
     # Elasticsearch
 
     - name: Post Install Tasks | Tsuru app-create elasticsearchapi
-      ignore_errors: yes
       shell: >
         tsuru app-create elasticsearchapi python -t admin
       when: "not 'elasticsearchapi' in tsuru_apps.stdout"

--- a/post-install.yml
+++ b/post-install.yml
@@ -216,8 +216,8 @@
 
     - name: Post Install Tasks | Add <deploy_env>-elasticsearchapi.<domain_name> cname to elasticsearchapi app
       shell: >
-        tsuru cname-add {{ elasticsearch_url }} -a elasticsearchapi
-      when: "not \"{{ elasticsearch_url }}\" in elasticsearchapi_app_info.stdout"
+        tsuru cname-add {{ elasticsearch_api }} -a elasticsearchapi
+      when: "not \"{{ elasticsearch_api }}\" in elasticsearchapi_app_info.stdout"
 
     - name: Post Install Tasks | Generate elasticsearchapi.yml
       copy:
@@ -226,7 +226,7 @@
           username: admin
           password: password
           endpoint:
-            production: https://{{ elasticsearch_url }}
+            production: https://{{ elasticsearch_api }}
         dest: ~/elasticsearchapi.yml
 
     - name: Post Install Tasks | Register elasticsearch service

--- a/post-install.yml
+++ b/post-install.yml
@@ -1,142 +1,144 @@
 - hosts: "{{ hosts_prefix }}-tsuru-api*[0]"
   sudo: yes
   tasks:
-    - name: Install git client
+    - name: Post Install Tasks | Install git client
       apt: name=git state=present
-    - name: Install crane
+    - name: Post Install Tasks | Install crane
       apt: name=crane state=present
-    - name: Check tsuru_deployer key
+    - name: Post Install Tasks | Check tsuru_deployer key
       stat: path=~/.ssh/tsuru_deployer
       register: tsuru_deployer_key
 
-    - name: Generate tsuru_deployer key
+    - name: Post Install Tasks | Generate tsuru_deployer key
       shell: >
         ssh-keygen -b 2048 -t rsa -f ~/.ssh/tsuru_deployer -q -N ""
       when: tsuru_deployer_key.stat.exists == False
-    - name: Generate tsuru_deployer.pub key
+    - name: Post Install Tasks | Generate tsuru_deployer.pub key
       shell: >
         ssh-keygen -y -f ~/.ssh/tsuru_deployer >~/.ssh/tsuru_deployer.pub
       when: tsuru_deployer_key.stat.exists == False
 
-    - name: Generate ssh config for git
+    - name: Post Install Tasks | Generate ssh config for git
       copy:
         content: |
           Host {{ deploy_env }}-gandalf.{{ domain_name }}
-            HostName {{ deploy_env }}-gandalf.{{ domain_name }} 
+            HostName {{ deploy_env }}-gandalf.{{ domain_name }}
             User git
             IdentityFile ~/.ssh/tsuru_deployer
-        dest: ~/.ssh/config        
+        dest: ~/.ssh/config
         mode: 0600
 
-    - name: Add Gandalf to known hosts
+    - name: Post Install Tasks | Add Gandalf to known hosts
       shell: >
         ssh-keyscan {{ deploy_env }}-gandalf.{{ domain_name }} >~/.ssh/known_hosts
 
-    - name: Tsuru pool-list
-      shell: > 
+    - name: Post Install Tasks | Tsuru pool-list
+      shell: >
         tsuru-admin pool-list
       register: tsuru_pools
-    - name: Tsuru pool add default
+    - name: Post Install Tasks | Tsuru pool add default
       shell: >
         tsuru-admin pool-add default
       when: "not 'default' in tsuru_pools.stdout"
-    - name: Check admin pool
+    - name: Post Install Tasks | Check admin pool
       shell: >
         tsuru pool-list | grep admin
       register: admin_pool
-    - name: Add admin team to default pool
+    - name: Post Install Tasks | Add admin team to default pool
       shell: >
         tsuru-admin pool-teams-add default admin
       when: "not 'default' in admin_pool.stdout"
 
-    - name: Tsuru platform-list
+    - name: Post Install Tasks | Tsuru platform-list
       shell: >
         tsuru platform-list | awk {'print $2'}
       register: tsuru_platforms
-    - name: Tsuru platform add python
+    - name: Post Install Tasks | Tsuru platform add python
       ignore_errors: no
       shell: >
         tsuru-admin platform-add python -d https://raw.github.com/tsuru/basebuilder/master/python/Dockerfile
       when: "not 'python' in tsuru_platforms.stdout"
-    - name: Tsuru platform add java
+    - name: Post Install Tasks | Tsuru platform add java
       ignore_errors: no
       shell: >
         tsuru-admin platform-add java -d https://raw.github.com/tsuru/basebuilder/master/java/Dockerfile
       when: "not 'java' in tsuru_platforms.stdout"
-    - name: Tsuru platform add static
+    - name: Post Install Tasks | Tsuru platform add static
       ignore_errors: no
       shell: >
         tsuru-admin platform-add static -d https://raw.github.com/tsuru/basebuilder/master/static/Dockerfile
       when: "not 'static' in tsuru_platforms.stdout"
 
-    - name: Tsuru key-list
+    - name: Post Install Tasks | Tsuru key-list
       shell: >
         tsuru key-list
       register: tsuru_keys
-    - name: Tsuru add ssh key
+    - name: Post Install Tasks | Tsuru add ssh key
       shell: >
         tsuru key-add tsuru_deployer ~/.ssh/tsuru_deployer.pub
       when: "not 'tsuru_deployer' in tsuru_keys.stdout"
 
-    - name: Tsuru app-list
+    - name: Post Install Tasks | Tsuru app-list
       shell: >
         tsuru app-list
       register: tsuru_apps
-    - name: Tsuru app-create dashboard
+    - name: Post Install Tasks | Tsuru app-create dashboard
       ignore_errors: yes
       shell: >
         tsuru app-create dashboard python -t admin
       when: "not 'dashboard' in tsuru_apps.stdout"
-    - name: Get gandalf repo for dashboard
+    - name: Post Install Tasks | Get gandalf repo for dashboard
       shell: >
         tsuru app-info -a dashboard | grep -o 'git@.\+'
       register: dashboard_git_remote
 
-    - name: Git pull dashboard
+    - name: Post Install Tasks | Git pull dashboard
       git:
         repo: https://github.com/tsuru/tsuru-dashboard.git
         dest: /tmp/tsuru-dashboard
 
-    - name: Git push dashboard to gandalf
+    - name: Post Install Tasks | Git push dashboard to gandalf
       shell: >
         git push {{ dashboard_git_remote.stdout }} master
-      args: 
+      args:
         chdir: /tmp/tsuru-dashboard
 
-    - name: Tsuru app-info dashboard
+    - name: Post Install Tasks | Tsuru app-info dashboard
       shell: >
         tsuru app-info -a dashboard
       register: dashboard_app_info
 
-    - name: Tsuru app-create postgresapi
+    # Adding postgresapi app
+
+    - name: Post Install Tasks | Tsuru app-create postgresapi
       ignore_errors: yes
       shell: >
         tsuru app-create postgresapi python -t admin
       when: "not 'postgresapi' in tsuru_apps.stdout"
 
-    - name: Git pull postgresapi
+    - name: Post Install Tasks | Git pull postgresapi
       git:
         repo: https://github.com/tsuru/postgres-api
         dest: /tmp/postgresapi
 
-    - name: Get gandalf repo for postgresapi
+    - name: Post Install Tasks | Get gandalf repo for postgresapi
       shell: >
         tsuru app-info -a postgresapi | grep -o 'git@.\+'
       register: postgresapi_git_remote
 
-    - name: Git push postgresapi to gandalf
+    - name: Post Install Tasks | Git push postgresapi to gandalf
       shell: >
         git push {{ postgresapi_git_remote.stdout }} master
       args:
         chdir: /tmp/postgresapi
       register: postgresapi_push_result
 
-    - name: Tsuru app-info postgresapi
+    - name: Post Install Tasks | Tsuru app-info postgresapi
       shell: >
         tsuru app-info -a postgresapi
       register: postgresapi_app_info
 
-    - name: Tsuru set environment variables for postgresapi
+    - name: Post Install Tasks | Tsuru set environment variables for postgresapi
       shell: >
         tsuru env-set -a postgresapi POSTGRESAPI_DATABASE=postgresapi;
         tsuru env-set -a postgresapi POSTGRESAPI_USER=postgresapi;
@@ -150,17 +152,17 @@
         tsuru env-set -a postgresapi POSTGRESAPI_SHARED_ADMIN_PASSWORD={{ pg_admin_pass }};
         tsuru env-set -a postgresapi POSTGRESAPI_SHARED_PUBLIC_HOST={{ postgres_master_host }};
       when: "not 'Everything up-to-date' in postgresapi_push_result.stderr"
-    - name: Tsuru app-run db upgrade
+    - name: Post Install Tasks | Tsuru app-run db upgrade
       shell: >
         tsuru app-run --app postgresapi -- python manage.py upgrade_db
       when: "not 'Everything up-to-date' in postgresapi_push_result.stderr"
 
-    - name: Add <deploy_env>-postgresapi<domain_name> cname to posgtresqlapi app
+    - name: Post Install Tasks | Add <deploy_env>-postgresapi.<domain_name> cname to posgtresqlapi app
       shell: >
         tsuru cname-add {{ deploy_env }}-postgresapi.{{ domain_name }} -a postgresapi
       when: "not '-postgresapi.' in postgresapi_app_info.stdout"
 
-    - name: Generate postgresapi.yml
+    - name: Post Install Tasks | Generate postgresapi.yml
       copy:
         content: |
           id: postgresql
@@ -169,11 +171,11 @@
             production: https://{{ deploy_env }}-postgresapi.{{ domain_name }}
         dest: ~/postgresapi.yml
 
-    - name: Get service list
+    - name: Post Install Tasks | Get service list
       shell: >
         tsuru service-list
       register: service_list
-    - name: Register service
+    - name: Post Install Tasks | Register service
       shell: >
         crane create ~/postgresapi.yml
       when: "not 'postgresql' in service_list.stdout"

--- a/site.yml
+++ b/site.yml
@@ -60,6 +60,7 @@
       when: "not ansible_default_ipv4.address in docker_node_list.stdout"
 
 - include: postgres.yml
+- include: elasticsearch.yml
 - include: router.yml
 - include: influx_grafana.yml
 - include: post-install.yml


### PR DESCRIPTION
Configure elasticsearch service - install server, deploy broker to tsuru and register the service.  Elasticsearch service is required for the [performance tests](https://www.pivotaltracker.com/n/projects/1275640/stories/99395802). 

This PR depends on https://github.com/alphagov/tsuru-terraform/pull/91.
