### PR TITLE
[#98824506] Restore postgres to a different IP

### DIFF
--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -35,4 +35,4 @@ postgresql_archive_command: >
   /usr/bin/envdir {{ wal_e_envdir }} /usr/local/bin/wal-e
   {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} wal-push %p
 
-postgres_host: "{{ deploy_env }}-postgres-master.{{ domain_name }}"
+postgres_master_host: "{{ deploy_env }}-postgres-master.{{ domain_name }}"

--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -34,3 +34,5 @@ wal_e_pgdata_dir: "/var/lib/postgresql/{{ postgresql_version }}/main/"
 postgresql_archive_command: >
   /usr/bin/envdir {{ wal_e_envdir }} /usr/local/bin/wal-e
   {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} wal-push %p
+
+postgres_host: "{{ deploy_env }}-postgres-master.{{ domain_name }}"

--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -20,10 +20,6 @@ gandalf_host_internal: "{{ hostvars[groups[gandalf_host_name][0]][ip_field_name]
 mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
 mongodb_host: "{{ hostvars[groups[mongodb_host_name][0]][ip_field_name] }}"
 
-postgres_host_name: "{{ hosts_prefix }}-tsuru-postgres-0"
-postgres_host: "{{ deploy_env }}-postgres-master.{{ domain_name }}"
-postgres_master: "{{ hostvars[groups[postgres_host_name][0]][ip_field_name] }}"
-
 influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"
 influxdb_url: "http://{{ hostvars[groups[influxdb_host_name][0]][ip_field_name] }}:8086"
 

--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -21,7 +21,7 @@ mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
 mongodb_host: "{{ hostvars[groups[mongodb_host_name][0]][ip_field_name] }}"
 
 postgres_host_name: "{{ hosts_prefix }}-tsuru-postgres-0"
-postgres_host: "{{ hostvars[groups[postgres_host_name][0]][ip_field_name] }}"
+postgres_host: "{{ deploy_env }}-postgres-master.{{ domain_name }}"
 postgres_master: "{{ hostvars[groups[postgres_host_name][0]][ip_field_name] }}"
 
 influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -21,7 +21,7 @@ mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
 mongodb_host: "{{ hostvars[mongodb_host_name][ip_field_name] }}"
 
 postgres_host_name: "{{ hosts_prefix }}-tsuru-postgres-0"
-postgres_host: "{{ hostvars[postgres_host_name][ip_field_name] }}"
+postgres_host: "{{ deploy_env }}-postgres-master.{{ domain_name }}"
 postgres_master: "{{ hostvars[postgres_host_name][ip_field_name] }}"
 
 influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -20,10 +20,6 @@ gandalf_host_internal: "{{ hostvars[gandalf_host_name][ip_field_name] }}"
 mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
 mongodb_host: "{{ hostvars[mongodb_host_name][ip_field_name] }}"
 
-postgres_host_name: "{{ hosts_prefix }}-tsuru-postgres-0"
-postgres_host: "{{ deploy_env }}-postgres-master.{{ domain_name }}"
-postgres_master: "{{ hostvars[postgres_host_name][ip_field_name] }}"
-
 influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"
 influxdb_url: "http://{{ hostvars[influxdb_host_name][ip_field_name] }}:8086"
 

--- a/post-install.yml
+++ b/post-install.yml
@@ -141,14 +141,14 @@
         tsuru env-set -a postgresapi POSTGRESAPI_DATABASE=postgresapi;
         tsuru env-set -a postgresapi POSTGRESAPI_USER=postgresapi;
         tsuru env-set -a postgresapi POSTGRESAPI_PASSWORD={{ pg_apiuser_pass }};
-        tsuru env-set -a postgresapi POSTGRESAPI_HOST={{ postgres_host }};
+        tsuru env-set -a postgresapi POSTGRESAPI_HOST={{ postgres_master_host }};
         tsuru env-set -a postgresapi POSTGRESAPI_PORT=5432;
         tsuru env-set -a postgresapi POSTGRESAPI_SALT=md5;
-        tsuru env-set -a postgresapi POSTGRESAPI_SHARED_HOST={{ postgres_host }};
+        tsuru env-set -a postgresapi POSTGRESAPI_SHARED_HOST={{ postgres_master_host }};
         tsuru env-set -a postgresapi POSTGRESAPI_SHARED_PORT=5432;
         tsuru env-set -a postgresapi POSTGRESAPI_SHARED_ADMIN=postgresadmin;
         tsuru env-set -a postgresapi POSTGRESAPI_SHARED_ADMIN_PASSWORD={{ pg_admin_pass }};
-        tsuru env-set -a postgresapi POSTGRESAPI_SHARED_PUBLIC_HOST={{ postgres_host }};
+        tsuru env-set -a postgresapi POSTGRESAPI_SHARED_PUBLIC_HOST={{ postgres_master_host }};
       when: "not 'Everything up-to-date' in postgresapi_push_result.stderr"
     - name: Tsuru app-run db upgrade
       shell: >

--- a/postgres.yml
+++ b/postgres.yml
@@ -7,13 +7,13 @@
 
   pre_tasks:
     - name: "PostgreSQL | Get Postgres Master IP from DNS"
-      shell: "dig +short {{ postgres_host }}"
-      register: postgres_master_IP_dig
+      shell: "dig +short {{ postgres_master_host }}"
+      register: postgres_master_ip_from_dig
     - name: "PostgreSQL | Set Postgres Master IP fact"
       set_fact:
-        postgres_master: "{{ postgres_master_IP_dig.stdout }}"
+        postgres_master_ip: "{{ postgres_master_ip_from_dig.stdout }}"
     - include_vars: postgres_master_vars.yml
-      when: "ansible_default_ipv4.address == postgres_master"
+      when: "ansible_default_ipv4.address == postgres_master_ip"
 
   roles:
     - ANXS.postgresql
@@ -21,6 +21,6 @@
 
   post_tasks:
     - include: postgres_master_post.yml
-      when: "ansible_default_ipv4.address == postgres_master"
+      when: "ansible_default_ipv4.address == postgres_master_ip"
     - include: postgres_standby_post.yml
-      when: "ansible_default_ipv4.address != postgres_master"
+      when: "ansible_default_ipv4.address != postgres_master_ip"

--- a/postgres.yml
+++ b/postgres.yml
@@ -6,6 +6,12 @@
     - "postgres_common_vars.yml"
 
   pre_tasks:
+    - name: "PostgreSQL | Get Postgres Master IP from DNS"
+      shell: "dig +short {{ postgres_host }}"
+      register: postgres_master_IP_dig
+    - name: "PostgreSQL | Set Postgres Master IP fact"
+      set_fact:
+        postgres_master: "{{ postgres_master_IP_dig.stdout }}"
     - include_vars: postgres_master_vars.yml
       when: "ansible_default_ipv4.address == postgres_master"
 

--- a/templates/recovery.conf.j2
+++ b/templates/recovery.conf.j2
@@ -5,4 +5,4 @@ standby_mode = 'on'
 restore_command ='/usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} wal-fetch "%f" "%p"'
 
 # replication configuration
-primary_conninfo = 'host={{ postgres_host }} port=5432 user=replication password={{ pg_replicationuser_pass }}'
+primary_conninfo = 'host={{ postgres_master_host }} port=5432 user=replication password={{ pg_replicationuser_pass }}'


### PR DESCRIPTION
We may need to restore a postgres database to a different host with a different IP address. This means we will need to repoint the postgres server instance to the new IP address and ensure that any apps consuming the database are still working correctly.

Since we already have a hot standby host, we test by promoting the standby to master.
# How to review
## Initial state
- Build a new environment or update one with the latest terraform so it includes the Postgres Master DNS record
- In the case of a previous environment, remove the postgresapi application
- Run ansible from this PR
- Deploy the [flask-postgres application](https://github.com/alphagov/flask-sqlalchemy-postgres-heroku-example) (with postgres service)
- Enter a few posts
## Failover
- Stop the master postgres node (postgres-0)
- Reload the flask application. It should fail now.
- Manually change the DNS record _env_-postgres-master.tsuru[2].paas.alphagov.co.uk to point to the standby node (postgres-1)
- Wait for the flask app to see the new IP (1-2 min). Ex:

``` bash
tsuru app-run "ping smashmouth-postgres-master.tsuru.paas.alphagov.co.uk" -a flask
```
- Reload the flask app. You should be able to read the previous content but you can't write a new post
- _Promote the standby node to master._ On standby, as user postgres, run: `pg_ctlcluster 9.3 main  promote`
- Reload the flask application. It should work read write now
## Finish new Master configuration
- Run ansible: `make gce DEPLOY_ENV=colin ARGS='-l colin-tsuru-postgres-1'`
- Create initial backup, as posgtres, run: `/usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e  backup-push  /var/lib/postgresql/9.3/main/`
- Check the backup list:

``` bash
postgres@colin-tsuru-postgres-1:~$ /usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e  backup-list
wal_e.main   INFO     MSG: starting WAL-E
        DETAIL: The subcommand is "backup-list".
        STRUCTURED: time=2015-07-23T13:32:16.714644-00 pid=3485
name    last_modified   expanded_size_bytes     wal_segment_backup_start        wal_segment_offset_backup_start wal_segment_backup_stop wal_segment_offset_backup_stop
base_000000010000000000000002_00000040  2015-07-23T11:06:00.245Z                000000010000000000000002        00000040                
base_000000020000000000000005_00000040  2015-07-23T13:31:26.010Z                000000020000000000000005        00000040
```

Observe the new timeline break: base_00000001\* -> base_00000002*
## Reconfigure new standby node
- Taint old postgres master

``` bash
(base)MacBook-Air-de-Colin:gce colin$ terraform taint -state=colin.tfstate google_compute_instance.postgres.0 
The resource google_compute_instance.postgres.0 in the module root has been marked as tainted!
```
- Run terraform for postgres. **Not the whole terraform, otherwise the DNS will rollback**

``` bash
terraform apply -state=colin.tfstate -var env=colin -var force_destroy=true -target=google_compute_instance.postgres
```
- Run ansible on the new standby node

``` bash
make gce DEPLOY_ENV=colin ARGS='-l colin-tsuru-postgres-0'
```
## Failback (optional)

This is good to align with terraform configuration again. Run the same steps again.
# Who should review

Anyone but @actionjack and @saliceti @russss
