### PR TITLE
[#99688330] Use existing variable to select tsuru-api-0 host

### DIFF
--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -17,7 +17,7 @@
       apt: name=python-httplib2 state=present
 
 # Run these tasks explicitly on 1st API server as the rest of playbooks (post install) expect it
-- hosts: "{{ hosts_prefix }}-tsuru-api*[0]"
+- hosts: "{{ tsuru_api_host_name }}"
   sudo: yes
   tasks:
     - name: add admin team


### PR DESCRIPTION
The order of the hosts array isn't always consistent as demonstrated by:

```
(ansible)➜  tsuru-ansible git:(master) ✗ ansible all -i ec2.py -m shell -l 'tag_Name_dcarley-tsuru-api*[0]' -a 'hostname'
10.128.13.46 | success | rc=0 >>
ip-10-128-13-46

(ansible)➜  tsuru-ansible git:(master) ✗ ansible all -i ec2.py -m shell -l 'tag_Name_dcarley-tsuru-api-0' -a 'hostname'
10.128.11.176 | success | rc=0 >>
ip-10-128-11-176
```

This was causing the Docker "register node" task to occasionally hang
because it was delegated to the _other_ API node, which hadn't executed the
tasks to login and create `~/.tsuru_token`, so `tsuru-admin` was waiting for
an interactive login.

We have to use `tsuru_api_host_name` rather than `tsuru_api_host` (as used
in `delegate_to`) because `hosts:` expects a tag/host matcher rather than an
IP address.

---

Tested on new AWS and GCE environments.
