### PR TITLE
[#99688330] Close STDIN on some tsuru-admin commands

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -46,16 +46,16 @@
   post_tasks:
     - name: Register node.
       shell: >
-        tsuru-admin docker-node-add --register address=http://{{ ansible_default_ipv4.address }}:{{ docker_port }} pool=default
+        tsuru-admin docker-node-add --register address=http://{{ ansible_default_ipv4.address }}:{{ docker_port }} pool=default </dev/null
       delegate_to: "{{ tsuru_api_host }}"
     - name: Check docker nodes are in the default pool
       shell: >
-        tsuru-admin docker-node-list -f pool=default
+        tsuru-admin docker-node-list -f pool=default </dev/null
       delegate_to: "{{ tsuru_api_host }}"
       register: docker_node_list
     - name: Update docker node metadata for default pool
       shell: >
-        tsuru-admin docker-node-update http://{{ ansible_default_ipv4.address }}:{{ docker_port }} pool=default
+        tsuru-admin docker-node-update http://{{ ansible_default_ipv4.address }}:{{ docker_port }} pool=default </dev/null
       delegate_to: "{{ tsuru_api_host }}"
       when: "not ansible_default_ipv4.address in docker_node_list.stdout"
 


### PR DESCRIPTION
So that these tasks fail early with an error instead of waiting forever on
an interactive login when `~/.tsuru_token` is absent or invalid.

I did try changing these to use the `command` module in the hope that it
closed STDIN automatically, but it doesn't:
- http://docs.ansible.com/ansible/command_module.html

I also looked at a way to specify a timeout of how long to wait for a
command but it seems you need to use the `async` module to do this which
seems like too greater change:
- http://docs.ansible.com/ansible/playbooks_async.html

There are other `tsuru` and `tsuru-admin` commands in our codebase that I
haven't touched. It seems more important to fix these ones first because
they hang early in the deployment and prevent the core components from being
setup, whereas if the post-install hangs then you already have a partially
working environment and it should take less time to fix.

---

PS: This is stealing @keymon's idea from https://github.com/alphagov/tsuru-ansible/pull/128#issuecomment-122951113
