### PR TITLE
[#99133134] fix test that checks rebind of services

### DIFF
--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -144,15 +144,7 @@ describe "TsuruEndToEnd" do
       expect(@workspace.tsuru_command.stdout).to include query
     end
 
-    it "should be able to connect to the applitation via HTTPS with a valid cert" do
-      pending "We don't have a certificate for this :)"
-      sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
-      response = URI.parse("https://#{sampleapp_address}/").open()
-      expect(response.status).to eq(["200", "OK"])
-    end
-
     it "should be able to unbind and bind a service to an app" do
-      pending "There is already a bug filed: https://github.com/tsuru/postgres-api/issues/1"
       @workspace.tsuru_command.service_unbind(@sampleapp_db_instance, @sampleapp_name)
       expect(@workspace.tsuru_command.exit_status).to eql 0
       retries=5
@@ -165,6 +157,13 @@ describe "TsuruEndToEnd" do
       end
       expect(@workspace.tsuru_command.exit_status).to eql 0
       expect(@workspace.tsuru_command.stdout).to match /Instance .* is now bound to the app .*/
+    end
+
+    it "should be able to connect to the applitation via HTTPS with a valid cert" do
+      pending "We don't have a certificate for this :)"
+      sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
+      response = URI.parse("https://#{sampleapp_address}/").open()
+      expect(response.status).to eq(["200", "OK"])
     end
 
   end

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -155,7 +155,14 @@ describe "TsuruEndToEnd" do
       pending "There is already a bug filed: https://github.com/tsuru/postgres-api/issues/1"
       @workspace.tsuru_command.service_unbind(@sampleapp_db_instance, @sampleapp_name)
       expect(@workspace.tsuru_command.exit_status).to eql 0
-      @workspace.tsuru_command.service_bind(@sampleapp_db_instance, @sampleapp_name)
+      retries=5
+      begin
+        sleep 1
+        @workspace.tsuru_command.service_bind(@sampleapp_db_instance, @sampleapp_name)
+        expect(@workspace.tsuru_command.stderr).to_not match /This app is already bound to this service instance/m
+      rescue RSpec::Expectations::ExpectationNotMetError
+        retry if (retries -= 1) > 0
+      end
       expect(@workspace.tsuru_command.exit_status).to eql 0
       expect(@workspace.tsuru_command.stdout).to match /Instance .* is now bound to the app .*/
     end

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -144,7 +144,15 @@ describe "TsuruEndToEnd" do
       expect(@workspace.tsuru_command.stdout).to include query
     end
 
+    it "should be able to connect to the applitation via HTTPS with a valid cert" do
+      pending "We don't have a certificate for this :)"
+      sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
+      response = URI.parse("https://#{sampleapp_address}/").open()
+      expect(response.status).to eq(["200", "OK"])
+    end
+
     it "should be able to unbind and bind a service to an app" do
+      pending "There is already a bug filed: https://github.com/tsuru/postgres-api/issues/1"
       @workspace.tsuru_command.service_unbind(@sampleapp_db_instance, @sampleapp_name)
       expect(@workspace.tsuru_command.exit_status).to eql 0
       retries=5
@@ -157,13 +165,6 @@ describe "TsuruEndToEnd" do
       end
       expect(@workspace.tsuru_command.exit_status).to eql 0
       expect(@workspace.tsuru_command.stdout).to match /Instance .* is now bound to the app .*/
-    end
-
-    it "should be able to connect to the applitation via HTTPS with a valid cert" do
-      pending "We don't have a certificate for this :)"
-      sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
-      response = URI.parse("https://#{sampleapp_address}/").open()
-      expect(response.status).to eq(["200", "OK"])
     end
 
   end

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -153,9 +153,9 @@ describe "TsuruEndToEnd" do
 
     it "should be able to unbind and bind a service to an app" do
       pending "There is already a bug filed: https://github.com/tsuru/postgres-api/issues/1"
-      @workspace.tsuru_command.service_unbind('sampleapptestdb', @sampleapp_name)
+      @workspace.tsuru_command.service_unbind(@sampleapp_db_instance, @sampleapp_name)
       expect(@workspace.tsuru_command.exit_status).to eql 0
-      @workspace.tsuru_command.service_bind('sampleapptestdb', @sampleapp_name)
+      @workspace.tsuru_command.service_bind(@sampleapp_db_instance, @sampleapp_name)
       expect(@workspace.tsuru_command.exit_status).to eql 0
       expect(@workspace.tsuru_command.stdout).to match /Instance .* is now bound to the app .*/
     end


### PR DESCRIPTION
## Context

The test `should be able to unbind and bind a service to an app` was pending [due a bug in tsuru postgres-api`](https://github.com/tsuru/postgres-api/issues/1). 

~~This bug [has been fixed](https://github.com/tsuru/postgres-api/pull/12) so we can remove it from pending.~~ From the comments from Michael, it seems the bug is not really fixed. But some commits in this PR are still valid.

It was necessary to fix some minor bugs in the test itself.
## How to review this?

Just run the tests as described in the README.md: `make test-aws DEPLOY_ENV=<env> VERBOSE=true` or `make test-gce DEPLOY_ENV=<env> VERBOSE=true`

~~The test `should be able to unbind and bind a service to an app` should be successful.~~

The test `should be able to unbind and bind a service to an app` should be pending, but fail with a `stderr: Error: Failed to bind the instance "tst3507577341" to the app "sampleapp1437757051": role "tst3507577234c09" already exists` error.
## Who should review this

Anyone but @keymon
