### PR TITLE
[#99500102] Permission denied (publickey) on CI build

### DIFF
--- a/post-install.yml
+++ b/post-install.yml
@@ -68,12 +68,15 @@
 
     - name: Post Install Tasks | Tsuru key-list
       shell: >
-        tsuru key-list
+        tsuru key-list -n
       register: tsuru_keys
+    - name: Post Install Tasks | Get public key content
+      shell: cat ~/.ssh/tsuru_deployer.pub
+      register: public_key_content
     - name: Post Install Tasks | Tsuru add ssh key
       shell: >
         tsuru key-add tsuru_deployer ~/.ssh/tsuru_deployer.pub
-      when: "not 'tsuru_deployer' in tsuru_keys.stdout"
+      when: "not public_key_content.stdout in tsuru_keys.stdout"
 
     - name: Post Install Tasks | Tsuru app-list
       shell: >

--- a/post-install.yml
+++ b/post-install.yml
@@ -73,6 +73,10 @@
     - name: Post Install Tasks | Get public key content
       shell: cat ~/.ssh/tsuru_deployer.pub
       register: public_key_content
+    - name: Post Install Tasks | Tsuru remove old key
+      shell: >
+        tsuru key-remove -y tsuru_deployer
+      when: "not public_key_content.stdout in tsuru_keys.stdout and 'tsuru_deployer' in tsuru_keys.stdout"
     - name: Post Install Tasks | Tsuru add ssh key
       shell: >
         tsuru key-add tsuru_deployer ~/.ssh/tsuru_deployer.pub

--- a/post-install.yml
+++ b/post-install.yml
@@ -1,4 +1,4 @@
-- hosts: "{{ hosts_prefix }}-tsuru-api*[0]"
+- hosts: "{{ hosts_prefix }}-tsuru-api-0"
   sudo: yes
   tasks:
     - name: Post Install Tasks | Install git client

--- a/post-install.yml
+++ b/post-install.yml
@@ -66,17 +66,17 @@
         tsuru-admin platform-add static -d https://raw.github.com/tsuru/basebuilder/master/static/Dockerfile
       when: "not 'static' in tsuru_platforms.stdout"
 
-    - name: Post Install Tasks | Tsuru key-list
+    - name: Post Install Tasks | Tsuru list tsuru_deployer key
       shell: >
-        tsuru key-list -n
+        tsuru key-list -n | awk '$2 == "tsuru_deployer"'
       register: tsuru_keys
-    - name: Post Install Tasks | Get public key content
+    - name: Post Install Tasks | Get local key content
       shell: cat ~/.ssh/tsuru_deployer.pub
       register: public_key_content
     - name: Post Install Tasks | Tsuru remove old key
       shell: >
         tsuru key-remove -y tsuru_deployer
-      when: "not public_key_content.stdout in tsuru_keys.stdout and 'tsuru_deployer' in tsuru_keys.stdout"
+      when: "not public_key_content.stdout in tsuru_keys.stdout and tsuru_keys.stdout != ''"
     - name: Post Install Tasks | Tsuru add ssh key
       shell: >
         tsuru key-add tsuru_deployer ~/.ssh/tsuru_deployer.pub


### PR DESCRIPTION
We assume this error happens when the local SSH keys are deleted or changed. The previous behaviour doesn't check if the remote key in Tsuru has the same content so we may end up out of sync.

Now we compare the content of local and remote keys so the new key will be uploaded if it is different.
There is no need to delete the remote key as Tsuru will replace the key of the same name if the content is different.
# How to review
- Run Ansible on a clean environment: it should create the keys and upload the public key
- Rerun Ansible: it should do nothing
- Delete the keys: it should create the keys and upload the public key
# Who can review

Anyone but @saliceti
