### PR TITLE
[#99771782] De-dupe AWS/GCE variables

### DIFF
--- a/gce.py
+++ b/gce.py
@@ -300,6 +300,9 @@ class GceInventory(object):
             if groups.has_key(stat): groups[stat].append(name)
             else: groups[stat] = [name]
 
+            # FIXME: Hack for compatibility with `ec2.py`
+            groups[name] = [name]
+
         groups["_meta"] = meta
 
         return groups

--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -1,6 +1,11 @@
 ---
 
+redis_host_name: "{{ hosts_prefix }}-tsuru-db"
+redis_host: "{{ hostvars[groups[redis_host_name][0]][ip_field_name] }}"
 redis_port: 6379
+
+tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api-0"
+tsuru_api_host: "{{ hostvars[groups[tsuru_api_host_name][0]][ip_field_name] }}"
 api_port: 8080
 
 docker_registry_host: "{{ deploy_env }}-docker-registry.{{ domain_name }}"
@@ -10,16 +15,23 @@ docker_version: 1.7.0
 
 hipache_host_external_lb: "{{ deploy_env }}-hipache.{{ domain_name }}"
 
+influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"
+influxdb_url: "http://{{ hostvars[groups[influxdb_host_name][0]][ip_field_name] }}:8086"
 influxdb_database: influxdb
 influxdb_user: influxdb
 influx_pass: influxdb
 
+gandalf_host_name: "{{ hosts_prefix }}-tsuru-gandalf"
+gandalf_host_internal: "{{ hostvars[groups[gandalf_host_name][0]][ip_field_name] }}"
 gandalf_host_external: "{{ deploy_env }}-gandalf.{{ domain_name }}"
 gandalf_port: 8080
 
+mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
+mongodb_host: "{{ hostvars[groups[mongodb_host_name][0]][ip_field_name] }}"
 mongodb_conf_bind_ip: 0.0.0.0
 mongodb_port: 27017
 
+tsuru_api_external_lb: "{{ deploy_env }}-api.{{ domain_name }}"
 tsuru_api_external_url: https://{{ tsuru_api_external_lb }}:443
 tsuru_api_internal_url: https://{{ tsuru_api_internal_lb }}:443
 
@@ -38,4 +50,5 @@ postgresql_archive_command: >
 postgres_master_host: "{{ deploy_env }}-postgres-master.{{ domain_name }}"
 
 elasticsearch_host_name: "{{ hosts_prefix }}-tsuru-elasticsearch"
+elasticsearch_host: "{{ hostvars[groups[elasticsearch_host_name][0]][ip_field_name] }}"
 elasticsearch_api: "{{ deploy_env }}-elasticsearchapi.{{ domain_name }}"

--- a/platform-aws.yml
+++ b/platform-aws.yml
@@ -6,24 +6,7 @@ hosts_prefix: "tag_Name_{{ deploy_env }}"
 ssl_crt: "{{ aws_ssl_crt }}"
 ssl_key: "{{ aws_ssl_key }}"
 
-redis_host_name: "{{ hosts_prefix }}-tsuru-db"
-redis_host: "{{ hostvars[groups[redis_host_name][0]][ip_field_name] }}"
-
-tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api-0"
-tsuru_api_host: "{{ hostvars[groups[tsuru_api_host_name][0]][ip_field_name] }}"
 tsuru_api_internal_lb: "{{ deploy_env }}-api-int.{{ domain_name }}"
-tsuru_api_external_lb: "{{ deploy_env }}-api.{{ domain_name }}"
-
-gandalf_host_name: "{{ hosts_prefix }}-tsuru-gandalf"
-gandalf_host_internal: "{{ hostvars[groups[gandalf_host_name][0]][ip_field_name] }}"
-
-mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
-mongodb_host: "{{ hostvars[groups[mongodb_host_name][0]][ip_field_name] }}"
-
-elasticsearch_host: "{{ hostvars[groups[elasticsearch_host_name][0]][ip_field_name] }}"
-
-influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"
-influxdb_url: "http://{{ hostvars[groups[influxdb_host_name][0]][ip_field_name] }}:8086"
 
 # WAL-E Configuration
 wal_e_aws_instance_profile: true

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -6,24 +6,7 @@ hosts_prefix: "{{ deploy_env }}"
 ssl_crt: "{{ gce_ssl_crt }}"
 ssl_key: "{{ gce_ssl_key }}"
 
-redis_host_name: "{{ hosts_prefix }}-tsuru-db"
-redis_host: "{{ hostvars[redis_host_name][ip_field_name] }}"
-
-tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api-0"
-tsuru_api_host: "{{ hostvars[tsuru_api_host_name][ip_field_name] }}"
 tsuru_api_internal_lb: "{{ deploy_env }}-api.{{ domain_name }}"
-tsuru_api_external_lb: "{{ deploy_env }}-api.{{ domain_name }}"
-
-gandalf_host_name: "{{ hosts_prefix }}-tsuru-gandalf"
-gandalf_host_internal: "{{ hostvars[gandalf_host_name][ip_field_name] }}"
-
-mongodb_host_name: "{{ hosts_prefix }}-tsuru-db"
-mongodb_host: "{{ hostvars[mongodb_host_name][ip_field_name] }}"
-
-influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"
-influxdb_url: "http://{{ hostvars[influxdb_host_name][ip_field_name] }}:8086"
-
-elasticsearch_host: "{{ hostvars[elasticsearch_host_name][ip_field_name] }}"
 
 # WAL-E Configuration
 wal_e_aws_instance_profile: false

--- a/platform-gce.yml
+++ b/platform-gce.yml
@@ -11,8 +11,8 @@ redis_host: "{{ hostvars[redis_host_name][ip_field_name] }}"
 
 tsuru_api_host_name: "{{ hosts_prefix }}-tsuru-api-0"
 tsuru_api_host: "{{ hostvars[tsuru_api_host_name][ip_field_name] }}"
-tsuru_api_internal_lb: "{{ hosts_prefix }}-api.{{ domain_name }}"
-tsuru_api_external_lb: "{{ hosts_prefix }}-api.{{ domain_name }}"
+tsuru_api_internal_lb: "{{ deploy_env }}-api.{{ domain_name }}"
+tsuru_api_external_lb: "{{ deploy_env }}-api.{{ domain_name }}"
 
 gandalf_host_name: "{{ hosts_prefix }}-tsuru-gandalf"
 gandalf_host_internal: "{{ hostvars[gandalf_host_name][ip_field_name] }}"

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -17,7 +17,7 @@
       apt: name=python-httplib2 state=present
 
 # Run these tasks explicitly on 1st API server as the rest of playbooks (post install) expect it
-- hosts: "{{ tsuru_api_host_name }}"
+- hosts: "{{ hosts_prefix }}-tsuru-api-0"
   sudo: yes
   tasks:
     - name: add admin team


### PR DESCRIPTION
#### Add self-referencing group to gce.py

This is a hack so that we can de-duplicate the variables in
`platform-aws.yml` and `platform-gce.yml` by referring to the `hostvars` of
other nodes in a consistent way, e.g.

```
`hostvars[groups["{{ hosts_prefix }}-tsuru-api-0"][0]]`
```

This pattern is necessary on AWS because the `hostvars` dictionary is keyed
by the instance IP rather than it's `Name` tag and tags are not unique
across instances.

It might have been possible to do the same using jinja2 filters to select
entries with the appropriate attributes, but it looked to produce much more
complicated code.

I don't normally comment code, but this seems warranted since it's not at
all obvious why the code is doing that thing and we may want to find a
better solution in the future.
#### Use deploy_env instead of hosts_prefix for API LB

It just so happens that these two variables are the same for GCE. But for
simplicity and consistency with AWS, we should use `deploy_env`, which only
ever contains the name of the environment.
#### De-duplicate vars in platform-{aws,gce}.yml

The preceding commit allows us to refer to `hostvars` in the same way on AWS
and GCE. So we can move all of these variables to `group_vars` and not
duplicate them. Except for `tsuru_api_internal_lb` which is different.
#### Don't use var in hosts pattern for first API node

The preceding commit moved this variable from `platform-{aws,gce}.yml` to
`group_vars/all/globals.yml`. This seems to prevent Ansible from
interpolating this variable correctly:

```
PLAY [{{ tsuru_api_host_name }}] **********************************************
skipping: no hosts matched
```

Fix this by changing to a hosts pattern that only matches the first API
node. This is in keeping with the spirit of 3ff22e4, but unfortunately
leaves us with some duplication.

---

There was a suggestion of renaming the variables to `_ip` and `_server_name` in the story, but I think that's enough changes for a single PR. I'll either do that after or create a separate story.
