### PR TITLE
[#99421666 ] mongoDB: use default location for data storage

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -9,7 +9,7 @@
     - bennojoy.redis
     - greendayonfire.mongodb
 
-# MongoDB: migrate old /data/db dir to new location
+#FIXME: Remove when deployed to all environments
   post_tasks:
     - name: MongoDB | Check /data/db directory
       stat: path=/data/db

--- a/site.yml
+++ b/site.yml
@@ -3,6 +3,8 @@
 
 - hosts: "{{ hosts_prefix }}-tsuru-db"
   sudo: yes
+  vars:
+    mongodb_conf_dbpath: "/var/lib/mongodb"
   roles:
     - bennojoy.redis
     - greendayonfire.mongodb

--- a/site.yml
+++ b/site.yml
@@ -9,6 +9,26 @@
     - bennojoy.redis
     - greendayonfire.mongodb
 
+# MongoDB: migrate old /data/db dir to new location
+  post_tasks:
+    - name: MongoDB | Check /data/db directory
+      stat: path=/data/db
+      register: mongo_data_db
+    - name: MongoDB | Migrate data - stop mongo
+      service: name=mongod state=stopped
+      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
+    - name: MongoDB | Migrate data - prepare destination
+      shell: >
+        rm -rf {{ mongodb_conf_dbpath }}
+      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
+    - name: MongoDB | Migrate data - move data dir
+      shell: >
+        mv /data/db {{ mongodb_conf_dbpath }}
+      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
+    - name: MongoDB | Migrate data - start mongo
+      service: name=mongod state=started
+      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
+
 # tsuru core components.
 - hosts: "{{ hosts_prefix }}-tsuru-gandalf*"
   sudo: yes


### PR DESCRIPTION
### What

When deploying mongoDB, it is started for the 1st time with default config. It initializes default data directory. It is then very shortly aftewards reconfigure and reloaded, data directory pointing to /data/db. This sometimes this fails on AWS, as there's not always ~3.2GB disk space left (that much space might be in reality no needed, but mongoDB does this check and refuses to continue if there's less). On GCE default VM disk space is 2GB larger, so there's enough disk space. Nevertheless, we don't need non-default data location.
### Fix

Use default mondoDB storage directory (/var/lib/mondgodb) instead of /data/db. This way mongo doesn't need to initialize new data sotrage directory, for which it needs about 3GB of free space by default. This fixes out of disk space deployment issues, where mongo still consumes full initialization space for the old data directory and tries to allocate the same for the new dir.
### Testing
#### New deployment

Just do the ansible run on AWS. You can watch mongoDB logs and disk space on mongo node. It should not require additional 3GB to do new data directory initialization.
#### Existing deployment

Do the ansible run. This will point mongo back to the default directory - but which is empty. This is OK. It also doesn't remove old data directory, so the data is preserved. There is enough disk space for new data dir initialization, because the old data directory is initialized already (after 1st ansible run) and normally consumes just around 400MB. This leaves around 5+GB free disk space - which is enough for new data dir initialization.
### Migration

The post-install tasks will do migration for you, in essence:
- stop mongo
- move old directory (/data/db) to default location (/var/lib/mongodb)
- start mongo
### Data

The kind of data stored in mongo is essentially all the internal state of tsuru: Users, apps, services, keys etc. - essentially everything related to tsuru platform itself.
