### PR TITLE
Smoke test to unbind and bind service enabled.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gem 'rspec'
 gem 'serverspec', '~> 2.18.0'
 gem 'ansible_spec'
 gem 'highline'
-
+gem 'rake'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
     oj (2.12.9)
+    rake (10.4.2)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -44,6 +45,7 @@ PLATFORMS
 DEPENDENCIES
   ansible_spec
   highline
+  rake
   rspec
   serverspec (~> 2.18.0)
 

--- a/spec/endtoend/endtoend_spec.rb
+++ b/spec/endtoend/endtoend_spec.rb
@@ -144,15 +144,7 @@ describe "TsuruEndToEnd" do
       expect(@workspace.tsuru_command.stdout).to include query
     end
 
-    it "should be able to connect to the applitation via HTTPS with a valid cert" do
-      pending "We don't have a certificate for this :)"
-      sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
-      response = URI.parse("https://#{sampleapp_address}/").open()
-      expect(response.status).to eq(["200", "OK"])
-    end
-
     it "should be able to unbind and bind a service to an app" do
-      pending "There is already a bug filed: https://github.com/tsuru/postgres-api/issues/1"
       @workspace.tsuru_command.service_unbind(@sampleapp_db_instance, @sampleapp_name)
       expect(@workspace.tsuru_command.exit_status).to eql 0
       retries=5
@@ -167,8 +159,12 @@ describe "TsuruEndToEnd" do
       expect(@workspace.tsuru_command.stdout).to match /Instance .* is now bound to the app .*/
     end
 
+    it "should be able to connect to the applitation via HTTPS with a valid cert" do
+      pending "We don't have a certificate for this :)"
+      sampleapp_address = @workspace.tsuru_command.get_app_address(@sampleapp_name)
+      response = URI.parse("https://#{sampleapp_address}/").open()
+      expect(response.status).to eq(["200", "OK"])
+    end
+
   end
 end
-
-
-


### PR DESCRIPTION
# What

I have enabled the smoke test that tests unbinding
and binding of a service. It works now since the issue
in Postgres API has been fixed.

See https://github.com/tsuru/postgres-api/pull/14 for details.

I have also added rake to Gemfile as it was missing for some reason.
# How To Test

To test, please make sure you run Ansible to have your environment
up to date (newest version of Postgres API) and run smoke tests:

```
make test-gce DEPLOY_ENV=yourenvironment
```
# Who Should Test This

Anybody except @RichardKnop.
