### PR TITLE
[#100114432] Set SSL_CERT_FILE for ansible-galaxy command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ render-ssh-config: check-env-var
 ansible-galaxy: .ansible-galaxy.check
 .ansible-galaxy.check: requirements.yml
 	rm -rf -- roles/*
-	ansible-galaxy install -r requirements.yml --force
+	SSL_CERT_FILE=$(shell python -m certifi) ansible-galaxy install -r requirements.yml --force
 	touch .ansible-galaxy.check
 
 import-gpg-keys:


### PR DESCRIPTION
This now fails when running on my Mac (Yosemite):

```
(ansible)➜  tsuru-ansible git:(99420212-custom_ppa) ✗ make aws DEPLOY_ENV=dcarley
sed "s/DEPLOY_ENV/dcarley/g" ssh.config.template > ssh.config
rm -rf -- roles/*
ansible-galaxy install -r requirements.yml --force
- the API server (galaxy.ansible.com) is not responding, please try again later.
make: *** [.ansible-galaxy.check] Error 1
```

It works when specifying an alternative certificate bundle, like we do for
the GCE inventory script. This suggests that `galaxy.ansible.com` changed
their SSL certificate recently.
