### PR TITLE
[#99772862] deploy etcd unit

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -10,6 +10,8 @@
   version: v1.2.2
 - src: Stouts.grafana
   version: 2.0.1
+- src: retr0h.etcd
+  version: 9a612f2ab2dfd52a9be329030bb2227c4d582423
 
 # GDS created and maintained playbooks
 - name: docker_server

--- a/site.yml
+++ b/site.yml
@@ -1,33 +1,6 @@
 # Bring up db tier (redis, mongodb).
 - include: registry.yml
-
-- hosts: "{{ hosts_prefix }}-tsuru-db"
-  sudo: yes
-  vars:
-    mongodb_conf_dbpath: "/var/lib/mongodb"
-  roles:
-    - bennojoy.redis
-    - greendayonfire.mongodb
-
-#FIXME: Remove when deployed to all environments
-  post_tasks:
-    - name: MongoDB | Check /data/db directory
-      stat: path=/data/db
-      register: mongo_data_db
-    - name: MongoDB | Migrate data - stop mongo
-      service: name=mongod state=stopped
-      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
-    - name: MongoDB | Migrate data - prepare destination
-      shell: >
-        rm -rf {{ mongodb_conf_dbpath }}
-      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
-    - name: MongoDB | Migrate data - move data dir
-      shell: >
-        mv /data/db {{ mongodb_conf_dbpath }}
-      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
-    - name: MongoDB | Migrate data - start mongo
-      service: name=mongod state=started
-      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
+- include: tsuru_db.yml
 
 # tsuru core components.
 - hosts: "{{ hosts_prefix }}-tsuru-gandalf*"

--- a/tsuru_db.yml
+++ b/tsuru_db.yml
@@ -3,9 +3,15 @@
   sudo: yes
   vars:
     mongodb_conf_dbpath: "/var/lib/mongodb"
+    etcd_interface: eth0
+  pre_tasks:
+    - name: Add tsuru DB into etcd group
+      add_host: name={{ inventory_hostname }} groups=etcd
+      when: vulcand is defined and vulcand
   roles:
     - bennojoy.redis
     - greendayonfire.mongodb
+    - { role: retr0h.etcd, when: vulcand is defined and vulcand }
 
 #FIXME: Remove when deployed to all environments
   post_tasks:

--- a/tsuru_db.yml
+++ b/tsuru_db.yml
@@ -1,0 +1,28 @@
+---
+- hosts: "{{ hosts_prefix }}-tsuru-db"
+  sudo: yes
+  vars:
+    mongodb_conf_dbpath: "/var/lib/mongodb"
+  roles:
+    - bennojoy.redis
+    - greendayonfire.mongodb
+
+#FIXME: Remove when deployed to all environments
+  post_tasks:
+    - name: MongoDB | Check /data/db directory
+      stat: path=/data/db
+      register: mongo_data_db
+    - name: MongoDB | Migrate data - stop mongo
+      service: name=mongod state=stopped
+      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
+    - name: MongoDB | Migrate data - prepare destination
+      shell: >
+        rm -rf {{ mongodb_conf_dbpath }}
+      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
+    - name: MongoDB | Migrate data - move data dir
+      shell: >
+        mv /data/db {{ mongodb_conf_dbpath }}
+      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
+    - name: MongoDB | Migrate data - start mongo
+      service: name=mongod state=started
+      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir


### PR DESCRIPTION
[99772862 deploy etcd unit](https://www.pivotaltracker.com/n/projects/1275640/stories/99772862) -  Add to etcd our deployment. This is needed for integrating vulcanD router. For the purpose of closest comparison with hipache we deploy it in similar configuration to redis: single node cluster running on tsuru-db server.
#### Testing

Run the tsuru_db playbook having set vulcand variable to true: 
`ansible-playbook -i gce.py -e "@platform-gce.yml" -e "deploy_env=myEnv" tsuru_db.yml -e "vulcand=true" -vvvv`

Once deployed, you can test etcd (from one of hosts within your environment):
- insert data by `curl -L http://<tsuru_db_internal_IP>:2379/v2/keys/message -XPUT -d value="Hello world"`
- retrieve data via `curl -L http://<tsuru_db_internal_IP>:2379/v2/keys/message`

You can also test performance using apache bench:
- writing: `ab -u <(echo value=\"bar\") -n 100000 -c 200 http://<tsuru_db_internal_IP>:2379/v2/keys/bench`
- reading: `ab -n 100000 -c 200 http://<tsuru_db_internal_IP>:2379/v2/keys/bench`

You should get around 5000 req/s when writing and when 6000 reading.
#### Reviewing

Anyone can review this except @keymon and @mtekel
