### PR TITLE
[#99420212] Install all Tsuru packages from our PPA mirror

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -19,13 +19,13 @@
   version: v0.1.1
 - name: hipache
   src: https://github.com/alphagov/ansible-playbook-hipache.git
-  version: v0.0.2
+  version: v0.1.0
 - name: tsuru_api
   src: https://github.com/alphagov/ansible-playbook-tsuru_api.git
-  version: v0.0.4
+  version: v0.1.0
 - name: gandalf
   src: https://github.com/alphagov/ansible-playbook-gandalf.git
-  version: v0.0.2
+  version: v0.1.0
 - name: wal_e
   src: https://github.com/alphagov/ansible-playbook-wal-e.git
   version: v0.0.3

--- a/router.yml
+++ b/router.yml
@@ -1,12 +1,16 @@
 - hosts: "{{ hosts_prefix }}-tsuru-router*"
   sudo: yes
   vars:
+    tsuru_repo: 'ppa:multicloudpaas/tsuru'
     hipache_port: 8080
     upstream_port: "{{ api_port }}"
   vars_files:
     - "ssl_proxy_vars.yml"
   pre_tasks:
     - include: ssl_proxy_pre.yml
+      # FIXME: Remove when `tsuru_repo` is deployed.
+    - name: Remove upstream APT repo
+      apt_repository: repo='ppa:tsuru/ppa' state=absent
   roles:
     - role: hipache
       hipache_listen_port: "{{ hipache_port }}"

--- a/site.yml
+++ b/site.yml
@@ -5,6 +5,12 @@
 # tsuru core components.
 - hosts: "{{ hosts_prefix }}-tsuru-gandalf*"
   sudo: yes
+  vars:
+    tsuru_repo: 'ppa:multicloudpaas/tsuru'
+  pre_tasks:
+      # FIXME: Remove when `tsuru_repo` is deployed.
+    - name: Remove upstream APT repo
+      apt_repository: repo='ppa:tsuru/ppa' state=absent
   roles:
     - role: gandalf
       tsuru_api_endpoint: "{{ tsuru_api_internal_url }}"

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -2,7 +2,11 @@
   sudo: yes
   pre_tasks:
     - include: ssl_proxy_pre.yml
+      # FIXME: Remove when `tsuru_repo` is deployed.
+    - name: Remove upstream APT repo
+      apt_repository: repo='ppa:tsuru/ppa' state=absent
   vars:
+    tsuru_repo: 'ppa:multicloudpaas/tsuru'
     tsuru_api_listen_addr: 127.0.0.1
     upstream_port: "{{ api_port }}"
     tsuru_api_url: "{{ tsuru_api_external_url }}"


### PR DESCRIPTION
Install the Tsuru packages for the core components Hipache, Gandalf, and
API, from our own PPA which is a mirror of the upstream PPA. This allows us
to pin the version that we use for stability.

A limitation of PPAs whereby they only present the latest version meant that
if we have pinned the version number in our code then we would have been
unable to install when Tsuru release a new version.

We have to use `pre_tasks` to remove the upstream PPA which is no longer
installed by the playbooks when the `tsuru_repo` var is passed. This can be
removed once it has been deployed to all existing machines, so long as we
continue to pass `tsuru_repo`.

The next time we upgrade the packages in our PPA we'll need to think about
how we roll it out to existing environments. Whether we change all of the
playbooks to `state=latest` (which is a pain to variabilise because it's a
separate attribute from the version which we currently expose) or pin the
specific version (which is also a pain because we'd have to time the changes
perfectly). It feels like it's out of scope for now though.

---

I have tested this on a new and existing environment in AWS.
