### PR TITLE
[#99773188] Get a build of tsuru that supports vulcand

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -22,7 +22,7 @@
   version: v0.1.0
 - name: tsuru_api
   src: https://github.com/alphagov/ansible-playbook-tsuru_api.git
-  version: v0.1.0
+  version: v0.1.1
 - name: gandalf
   src: https://github.com/alphagov/ansible-playbook-gandalf.git
   version: v0.1.0

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -2,11 +2,18 @@
   sudo: yes
   pre_tasks:
     - include: ssl_proxy_pre.yml
+    - name: Remove daily snapshots repo
+      apt_repository: repo='ppa:tsuru/snapshots' state=absent
+      when: vulcand is undefined
+    - name: Remove our private repo
+      apt_repository: repo='ppa:multicloudpaas/tsuru' state=absent
+      when: vulcand is defined
       # FIXME: Remove when `tsuru_repo` is deployed.
     - name: Remove upstream APT repo
       apt_repository: repo='ppa:tsuru/ppa' state=absent
   vars:
-    tsuru_repo: 'ppa:multicloudpaas/tsuru'
+    tsuru_package_latest: true
+    tsuru_repo: "{% if vulcand is defined %}ppa:tsuru/snapshots{% else %}ppa:multicloudpaas/tsuru{% endif %}"
     tsuru_api_listen_addr: 127.0.0.1
     upstream_port: "{{ api_port }}"
     tsuru_api_url: "{{ tsuru_api_external_url }}"


### PR DESCRIPTION
To support vulcanD, we need latest, not yet released build of tsuru. We have decided to obtain it from the daily (nightly built) snapshots repository that tsuru provides. This PR enables that. To deploy latest tsuru snapshot to tsuru_api server, just set vulcand variable to true during your ansible run.
### How to test

Check out the ansible-playbook-tsuru_api locally into your ansible galaxy roles directory. Then run: `ansible-playbook -i gce.py -e "@platform-gce.yml" -e "deploy_env=yourEnvironment" tsuru_api.yml -e "vulcand=true"`
### Who can review

Anyone but @mtekel or @keymon 
