### PR TITLE
[#99420212] Move tsuru_repo variables to tighter scope

### DIFF
--- a/router.yml
+++ b/router.yml
@@ -1,7 +1,6 @@
 - hosts: "{{ hosts_prefix }}-tsuru-router*"
   sudo: yes
   vars:
-    tsuru_repo: 'ppa:multicloudpaas/tsuru'
     hipache_port: 8080
     upstream_port: "{{ api_port }}"
   vars_files:
@@ -13,6 +12,7 @@
       apt_repository: repo='ppa:tsuru/ppa' state=absent
   roles:
     - role: hipache
+      tsuru_repo: 'ppa:multicloudpaas/tsuru'
       hipache_listen_port: "{{ hipache_port }}"
       hipache_listen_address: '127.0.0.1'
       hipache_listen_address6: '::1'

--- a/site.yml
+++ b/site.yml
@@ -5,14 +5,13 @@
 # tsuru core components.
 - hosts: "{{ hosts_prefix }}-tsuru-gandalf*"
   sudo: yes
-  vars:
-    tsuru_repo: 'ppa:multicloudpaas/tsuru'
   pre_tasks:
       # FIXME: Remove when `tsuru_repo` is deployed.
     - name: Remove upstream APT repo
       apt_repository: repo='ppa:tsuru/ppa' state=absent
   roles:
     - role: gandalf
+      tsuru_repo: 'ppa:multicloudpaas/tsuru'
       tsuru_api_endpoint: "{{ tsuru_api_internal_url }}"
 
 - include: tsuru_api.yml

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -12,14 +12,14 @@
     - name: Remove upstream APT repo
       apt_repository: repo='ppa:tsuru/ppa' state=absent
   vars:
-    tsuru_package_latest: true
-    tsuru_api_listen_addr: 127.0.0.1
     upstream_port: "{{ api_port }}"
     tsuru_api_url: "{{ tsuru_api_external_url }}"
   vars_files:
     - "ssl_proxy_vars.yml"
   roles:
     - role: tsuru_api
+      tsuru_package_latest: true
+      tsuru_api_listen_addr: 127.0.0.1
       tsuru_repo: "{% if vulcand is defined %}ppa:tsuru/snapshots{% else %}ppa:multicloudpaas/tsuru{% endif %}"
       tags: tsuru_api
     - role: jdauphant.nginx

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -13,7 +13,6 @@
       apt_repository: repo='ppa:tsuru/ppa' state=absent
   vars:
     tsuru_package_latest: true
-    tsuru_repo: "{% if vulcand is defined %}ppa:tsuru/snapshots{% else %}ppa:multicloudpaas/tsuru{% endif %}"
     tsuru_api_listen_addr: 127.0.0.1
     upstream_port: "{{ api_port }}"
     tsuru_api_url: "{{ tsuru_api_external_url }}"
@@ -21,6 +20,7 @@
     - "ssl_proxy_vars.yml"
   roles:
     - role: tsuru_api
+      tsuru_repo: "{% if vulcand is defined %}ppa:tsuru/snapshots{% else %}ppa:multicloudpaas/tsuru{% endif %}"
       tags: tsuru_api
     - role: jdauphant.nginx
   tasks:


### PR DESCRIPTION
Apply them to the role that's using them rather than leaking them
everywhere. I should have done this in the first place. The `vars` in these
files are abstractions that are used further down.

---
#147 should go first and I'll rebase this after.
