### PR TITLE
[#98108998] SPOF on Ansible Galaxy

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,16 +1,22 @@
 # vim:ft=ansible:
 
-- src: aalda.docker-registry
+- name: aalda.docker-registry
+  src: https://github.com/codingbunch/ansible-docker-registry.git
   version: v1.0.6
-- src: jdauphant.nginx
+- name: jdauphant.nginx
+  src: https://github.com/jdauphant/ansible-role-nginx.git
   version: v1.3.4
-- src: ANXS.postgresql
+- name: ANXS.postgresql
+  src: https://github.com/ANXS/postgresql.git
   version: v1.1.2
-- src: greendayonfire.mongodb
+- name: greendayonfire.mongodb
+  src: https://github.com/UnderGreen/ansible-role-mongodb.git
   version: v1.2.2
-- src: Stouts.grafana
+- name: Stouts.grafana
+  src: https://github.com/Stouts/Stouts.grafana.git
   version: 2.0.1
-- src: retr0h.etcd
+- name: retr0h.etcd
+  src: https://github.com/retr0h/ansible-etcd.git
   version: 9a612f2ab2dfd52a9be329030bb2227c4d582423
 
 # GDS created and maintained playbooks


### PR DESCRIPTION
Ansible galaxy server resolves playbook names into links where to download these playbooks from. In our case, all these playbooks are on github. Put the resolved values directly into requirements.yml (ansible galaxy prints the resolution results when you run it), so that we don't rely on ansible galaxy server anymore.
