### PR TITLE
[#99772862] Trim vulcand etcd condition

### DIFF
--- a/tsuru_db.yml
+++ b/tsuru_db.yml
@@ -11,7 +11,7 @@
   roles:
     - bennojoy.redis
     - greendayonfire.mongodb
-    - { role: retr0h.etcd, when: vulcand is defined and vulcand }
+    - { role: retr0h.etcd, when: vulcand is defined }
 
 #FIXME: Remove when deployed to all environments
   post_tasks:


### PR DESCRIPTION
Remove `and vulcand` from `when: vulcand is defined and vulcand`. We don't want to test for specific contents of vulcand variable, just whether it is defined or not. This way we can use the value of variable to carry some other useful information, like vulcand version, or some other specific setting.
