### PR TITLE
[#99782882] Set the influxDB retention policy to 2 weeks

### DIFF
--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -20,6 +20,7 @@ influxdb_url: "http://{{ hostvars[groups[influxdb_host_name][0]][ip_field_name] 
 influxdb_database: influxdb
 influxdb_user: influxdb
 influx_pass: influxdb
+influxdb_retention_period: 2w
 
 gandalf_host_name: "{{ hosts_prefix }}-tsuru-gandalf"
 gandalf_host_internal: "{{ hostvars[groups[gandalf_host_name][0]][ip_field_name] }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -37,7 +37,7 @@
   version: v0.0.3
 - name: influxdb
   src: https://github.com/alphagov/ansible-playbook-influxdb.git
-  version: v0.0.1
+  version: v0.0.2
 - name: telegraf
   src: https://github.com/alphagov/ansible-playbook-telegraf.git
   version: v0.1.0


### PR DESCRIPTION
[Set the influxDB retention policy](https://www.pivotaltracker.com/story/show/99782882)

**What**

Currently InfluxDB has an infinite retention policy by default and simply fills the disk. This breaks ansible deploys, as ansible cannot even create temporary directories for its run.

We decided on a retention period of 2 weeks to allow for debugging of issues that we see on the platform. We may want to change this in prod.

**How this PR should be reviewed**

This PR has been written with the following narrative:
- I would like to pull in an updated `ansible` [influxdb](https://github.com/alphagov/ansible-playbook-influxdb/pull/2) role that lets me set the influxdb retention policy
- I would like to use the `influxdb_retention_period` variable to set the retention policy to 2 weeks (336 hours)

**How to test this PR**
- ssh into your influxdb as defined as your terraform `influx.private_ip` and do the following:

```
$ /opt/influxdb/versions/0.9.1/influx -database 'influxdb'
> > SHOW RETENTION POLICIES influxdb
name  duration  replicaN  default
default 336h0m0s  1   true
> EXIT
```

**Who should review this PR**
- An Bashful Badger, if a shy short-legged omnivore can not be readily found then any member of the core team will do
