### PR TITLE
[#99773312] Enable vulcand

### DIFF
--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -1,5 +1,9 @@
 ---
 
+etcd_host_name: "{{ hosts_prefix }}-tsuru-db"
+etcd_host: "{{ hostvars[groups[etcd_host_name][0]][ip_field_name] }}"
+etcd_port: 2379
+
 redis_host_name: "{{ hosts_prefix }}-tsuru-db"
 redis_host: "{{ hostvars[groups[redis_host_name][0]][ip_field_name] }}"
 redis_port: 6379

--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -18,6 +18,9 @@ docker_port: 4243
 docker_version: 1.7.0
 
 router_port: 8080
+router_api_port: 8081
+tsuru_router_host_name: "{{ hosts_prefix }}-tsuru-router-0"
+tsuru_router_host: "{{ hostvars[groups[tsuru_router_host_name][0]][ip_field_name] }}"
 hipache_host_external_lb: "{{ deploy_env }}-hipache.{{ domain_name }}"
 
 influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"

--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -13,6 +13,7 @@ docker_registry_port: 6000
 docker_port: 4243
 docker_version: 1.7.0
 
+router_port: 8080
 hipache_host_external_lb: "{{ deploy_env }}-hipache.{{ domain_name }}"
 
 influxdb_host_name: "{{ hosts_prefix }}-influx-grafana"

--- a/requirements.yml
+++ b/requirements.yml
@@ -28,7 +28,7 @@
   version: v0.1.0
 - name: tsuru_api
   src: https://github.com/alphagov/ansible-playbook-tsuru_api.git
-  version: v0.2.0
+  version: v0.3.0
 - name: gandalf
   src: https://github.com/alphagov/ansible-playbook-gandalf.git
   version: v0.1.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -28,7 +28,7 @@
   version: v0.1.0
 - name: tsuru_api
   src: https://github.com/alphagov/ansible-playbook-tsuru_api.git
-  version: v0.1.1
+  version: v0.2.0
 - name: gandalf
   src: https://github.com/alphagov/ansible-playbook-gandalf.git
   version: v0.1.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -41,6 +41,9 @@
 - name: telegraf
   src: https://github.com/alphagov/ansible-playbook-telegraf.git
   version: v0.1.0
+- name: vulcand
+  src: https://github.com/alphagov/ansible-playbook-vulcand.git
+  #version: not pinned because under development
 
 # GDS Forked, pull-request sent upstream awaiting merge.
 - name: bennojoy.redis

--- a/router.yml
+++ b/router.yml
@@ -1,8 +1,7 @@
 - hosts: "{{ hosts_prefix }}-tsuru-router*"
   sudo: yes
   vars:
-    hipache_port: 8080
-    upstream_port: "{{ api_port }}"
+    upstream_port: "{{ router_port }}"
   vars_files:
     - "ssl_proxy_vars.yml"
   pre_tasks:
@@ -13,7 +12,7 @@
   roles:
     - role: hipache
       tsuru_repo: 'ppa:multicloudpaas/tsuru'
-      hipache_listen_port: "{{ hipache_port }}"
+      hipache_listen_port: "{{ router_port }}"
       hipache_listen_address: '127.0.0.1'
       hipache_listen_address6: '::1'
     - role: jdauphant.nginx

--- a/router.yml
+++ b/router.yml
@@ -20,6 +20,7 @@
       vulcand_version: 'v0.8.0-beta.3'
       vulcand_args:
         port: "{{ router_port }}"
+        apiPort: "{{ router_api_port }}"
         etcd: "http://{{ etcd_host }}:{{ etcd_port }}"
       when: vulcand is defined
     - role: jdauphant.nginx

--- a/router.yml
+++ b/router.yml
@@ -15,4 +15,11 @@
       hipache_listen_port: "{{ router_port }}"
       hipache_listen_address: '127.0.0.1'
       hipache_listen_address6: '::1'
+      when: vulcand is not defined
+    - role: vulcand
+      vulcand_version: 'v0.8.0-beta.3'
+      vulcand_args:
+        port: "{{ router_port }}"
+        etcd: "http://{{ etcd_host }}:{{ etcd_port }}"
+      when: vulcand is defined
     - role: jdauphant.nginx

--- a/tsuru_api.yml
+++ b/tsuru_api.yml
@@ -12,6 +12,12 @@
     - name: Remove upstream APT repo
       apt_repository: repo='ppa:tsuru/ppa' state=absent
   vars:
+    router_config_vulcand:
+      domain: "{{ hipache_host_external_lb }}"
+      api-url: "http://{{ tsuru_router_host }}:{{ router_api_port }}"
+    router_config_hipache:
+      domain: "{{ hipache_host_external_lb }}"
+      redis-server: "{{ redis_host }}:{{ redis_port }}"
     upstream_port: "{{ api_port }}"
     tsuru_api_url: "{{ tsuru_api_external_url }}"
   vars_files:
@@ -21,6 +27,8 @@
       tsuru_package_latest: true
       tsuru_api_listen_addr: 127.0.0.1
       tsuru_repo: "{% if vulcand is defined %}ppa:tsuru/snapshots{% else %}ppa:multicloudpaas/tsuru{% endif %}"
+      tsuru_router_type: "{% if vulcand is defined %}vulcand{% else %}hipache{% endif %}"
+      tsuru_router_config: "{% if vulcand is defined %}{{ router_config_vulcand }}{% else %}{{ router_config_hipache }}{% endif %}"
       tags: tsuru_api
     - role: jdauphant.nginx
   tasks:


### PR DESCRIPTION
#### Rename var hipache_port to router_port

To reflect the fact that it will be used for both Hipache and Vulcand. We
can move it to `group_vars` at the same time, to match `docker_port` and
`redis_port`, which makes it slightly clearer that the variable name is
different from the one being passed to the actual role.
#### Optionally install vulcand on the router nodes

Instead of Hipache, when the `vulcand` feature flag is enabled. Version is
the latest stable. Port is the same as Hipache. It's using the single etcd
endpoint which is running on the DB host.

Per the comment in `requirements.yml`, I haven't pinned the version of the
playbook because it may be under active development while we're testing and
it'll be easier to not make two stage releases. We should version it if we
continue to use it in the future.

NB: This isn't intended to convert an existing environment from Hipache to
Vulcand. The ports of the routers will clash and the previously deployed applications won't be properly registered in vulcand. We only intend to create new environments, for testing, with this feature flag.
#### Optionally configure Tsuru API for vulcand

When the `vulcand` feature flag is enabled. The playbook version is being
bumped at the same time (with backwards incompat changes) so that we can
configure the router. I've arbitrarily chosen/set the API port, because we
need to pass the same value to both vulcand and Tsuru API.

I'm going to create tech debt stories for the following:
- the Tsuru API is only using the first router host for Vulcand's API. If we
  use vulcand beyond testing then we should fix this single point of
  failure
- the variable `hipache_host_external_lb` and the DNS hostname that is
  reference should be renamed from "hipache" to "router", so that it's
  agnostic of the actual router we use

---

In order to test this ~~you will need to workaround [missing queue configuration in `tsuru.conf`](https://www.pivotaltracker.com/story/show/100310408) (merged)~~. Additionally an unrelated [test for log output will fail](https://www.pivotaltracker.com/story/show/100407030) and we discovered a problem [removing applications that have CNAMEs](https://www.pivotaltracker.com/story/show/100406746).
