### PR TITLE
[#95512034] Enable SSH pipelining for Ansible

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -194,7 +194,7 @@ ssh_args = -o ControlMaster=auto -o ControlPersist=60s -F ssh.config
 # By default, this option is disabled to preserve compatibility with
 # sudoers configurations that have requiretty (the default on many distros).
 #
-#pipelining = False
+pipelining = True
 
 # if True, make ansible use scp if the connection type is ssh
 # (default is sftp)


### PR DESCRIPTION
This cuts 1 minute off the time it takes (3m47s to 2m38s) to run Ansible
across all machines in an existing environment. I haven't compared the time
it takes to provision an environment from scratch, but I suspect it will be
a similar ratio (not dramatically different).

Per the warning in the comment, the Ubuntu images that we use on AWS and GCE
do not have `requiretty` enabled by default. I've confirmed this by looking
at `/etc/sudoers` and provisioning a new machine on each provider.

Before:

```
PLAY RECAP ********************************************************************
10.128.10.24               : ok=24   changed=6    unreachable=0    failed=0
10.128.10.250              : ok=5    changed=0    unreachable=0    failed=0
10.128.10.8                : ok=21   changed=3    unreachable=0    failed=0
10.128.11.106              : ok=70   changed=22   unreachable=0    failed=0
10.128.11.138              : ok=31   changed=0    unreachable=0    failed=0
10.128.11.149              : ok=16   changed=2    unreachable=0    failed=0
10.128.11.19               : ok=21   changed=0    unreachable=0    failed=0
10.128.11.38               : ok=40   changed=4    unreachable=0    failed=0
10.128.11.47               : ok=44   changed=5    unreachable=0    failed=0
10.128.11.73               : ok=10   changed=0    unreachable=0    failed=0
10.128.13.162              : ok=31   changed=0    unreachable=0    failed=0
10.128.13.246              : ok=32   changed=1    unreachable=0    failed=0
10.128.13.28               : ok=16   changed=2    unreachable=0    failed=0
10.128.13.36               : ok=31   changed=2    unreachable=0    failed=0

make aws DEPLOY_ENV=dcarley ARGS='-e vulcand=true'  36.80s user 17.77s system 24% cpu 3:47.28 total
```

After:

```
PLAY RECAP ********************************************************************
10.128.10.24               : ok=24   changed=6    unreachable=0    failed=0
10.128.10.250              : ok=5    changed=0    unreachable=0    failed=0
10.128.10.8                : ok=21   changed=3    unreachable=0    failed=0
10.128.11.106              : ok=70   changed=22   unreachable=0    failed=0
10.128.11.138              : ok=31   changed=0    unreachable=0    failed=0
10.128.11.149              : ok=16   changed=2    unreachable=0    failed=0
10.128.11.19               : ok=21   changed=0    unreachable=0    failed=0
10.128.11.38               : ok=40   changed=4    unreachable=0    failed=0
10.128.11.47               : ok=44   changed=5    unreachable=0    failed=0
10.128.11.73               : ok=10   changed=0    unreachable=0    failed=0
10.128.13.162              : ok=31   changed=0    unreachable=0    failed=0
10.128.13.246              : ok=32   changed=1    unreachable=0    failed=0
10.128.13.28               : ok=16   changed=2    unreachable=0    failed=0
10.128.13.36               : ok=31   changed=2    unreachable=0    failed=0

make aws DEPLOY_ENV=dcarley ARGS='-e vulcand=true'  30.47s user 11.66s system 26% cpu 2:38.91 total
```
