### PR TITLE
[#99773620] Rename tsr to tsurud when using snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,14 @@ Quick one-liner:
 ```
 ssh -F ssh.config postgres-host.domain.com "sudo -u postgres psql -c 'DROP role sampleapp_3f9ef5;'"
 ```
+
+#### Vulcand support
+
+We are testing [Vulcand](https://vulcand.io/) support as a possible replacement to [hipache](https://github.com/hipache/hipache).
+
+To test this:
+
+```
+make aws DEPLOY_ENV=... ARGS='-e "vulcand=true"'
+make gce DEPLOY_ENV=... ARGS='-e "vulcand=true"'
+```

--- a/site.yml
+++ b/site.yml
@@ -18,10 +18,12 @@
 
 - hosts: "{{ hosts_prefix }}-tsuru-gandalf*"
   sudo: yes
+  vars:
+    tsuru_cmd: "{% if vulcand is defined %}tsurud{% else %}tsr{% endif %}"
   tasks:
     - name: generate tsuru token
       run_once: true
-      shell: tsr token
+      shell: "{{ tsuru_cmd }} token"
       delegate_to: "{{ tsuru_api_host }}"
       register: tsr_token
 


### PR DESCRIPTION
The `tsr` binary has been renamed to `tsurud` (tsuru/tsuru#1192) in the
snapshot releases which prevents this command from running when we're using
our `vulcand` feature flag. We'll need to update this again when the stable
release is out.

The service is unaffected because the package ships the binary and init
script at the same time.

---

This blocked us from working on the referenced story.
