### PR TITLE
Revert 100407030 support websockets nginx

### DIFF
--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -15,7 +15,6 @@ nginx_sites:
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
-      proxy_set_header Origin http://localhost:{{ upstream_port }};
       }
   default:
     - listen 80

--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -12,9 +12,6 @@ nginx_sites:
       proxy_redirect http://$hostname/ https://$host/;
       proxy_connect_timeout 15s;
       proxy_buffering off;
-      proxy_http_version 1.1;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $connection_upgrade;
       }
   default:
     - listen 80
@@ -25,5 +22,3 @@ nginx_configs:
     - proxy_set_header X-Real-IP  $remote_addr
     - proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
     - proxy_set_header X-Forwarded-Proto https
-  websocket_map:
-    - map $http_upgrade $connection_upgrade { default Upgrade; '' close; }


### PR DESCRIPTION
For some reason (to be investigated yet) this breaks hipache. It then doesn't find any apps. Like it is trying to access some other domain. Proxy http_version 1.1 doesn't break anything, but was part of the original commit, hence reverting together.
