### PR TITLE
[#99773620] Use vulcand for HTTPS/SSL termination

### DIFF
--- a/router.yml
+++ b/router.yml
@@ -2,6 +2,7 @@
   sudo: yes
   vars:
     upstream_port: "{{ router_port }}"
+    vulcand_sealkey_file: "/etc/vulcand.sealkey"
   vars_files:
     - "ssl_proxy_vars.yml"
   pre_tasks:
@@ -9,6 +10,21 @@
       # FIXME: Remove when `tsuru_repo` is deployed.
     - name: Remove upstream APT repo
       apt_repository: repo='ppa:tsuru/ppa' state=absent
+    - name: vulcand | Read or generate seal key
+      shell: >
+        [ -f {{ vulcand_sealkey_file }} ] &&
+        cat {{ vulcand_sealkey_file }} ||
+        dd if=/dev/urandom count=32 bs=1 2> /dev/null |
+          od -A n -t x1 | tr -d ' \n'
+      register: vulcand_sealkey
+      run_once: true
+      when: vulcand is defined
+    - name: vulcand | Write seal key
+      copy:
+        dest: "{{ vulcand_sealkey_file }}"
+        content: "{{ vulcand_sealkey.stdout }}"
+        mode: 0600
+      when: vulcand is defined
   roles:
     - role: hipache
       tsuru_repo: 'ppa:multicloudpaas/tsuru'
@@ -22,5 +38,6 @@
         port: "{{ router_port }}"
         apiPort: "{{ router_api_port }}"
         etcd: "http://{{ etcd_host }}:{{ etcd_port }}"
+        sealKey: "{{ vulcand_sealkey.stdout }}"
       when: vulcand is defined
     - role: jdauphant.nginx

--- a/router.yml
+++ b/router.yml
@@ -7,6 +7,16 @@
     - "ssl_proxy_vars.yml"
   pre_tasks:
     - include: ssl_proxy_pre.yml
+    - name: "Router | Include SSL proxy varrs"
+      include_vars: ssl_proxy_vars.yml
+      when: vulcand is not defined
+    - name: "Router | set http to https redirect"
+      set_fact:
+        nginx_sites:
+          default:
+          - listen 80
+          - return 301 https://$host$request_uri
+      when: vulcand is defined
       # FIXME: Remove when `tsuru_repo` is deployed.
     - name: Remove upstream APT repo
       apt_repository: repo='ppa:tsuru/ppa' state=absent

--- a/router.yml
+++ b/router.yml
@@ -51,3 +51,23 @@
         sealKey: "{{ vulcand_sealkey.stdout }}"
       when: vulcand is defined
     - role: jdauphant.nginx
+  post_tasks:
+    - name: vulcand | Configure SSL host
+      shell: >
+        {{ vulcand_install_path }}/vctl \
+          --vulcan "http://{{ tsuru_router_host }}:{{ router_api_port }}" \
+          host upsert \
+          --name default \
+          --cert=/etc/nginx/wildcard.{{ domain_name }}.site.chain.crt  \
+          --privateKey=/etc/nginx/wildcard.{{ domain_name }}.key
+      when: vulcand is defined
+    - name: vulcand | Configure SSL listener in port 443
+      shell: >
+        {{ vulcand_install_path }}/vctl \
+          --vulcan "http://{{ tsuru_router_host }}:{{ router_api_port }}" \
+          listener upsert \
+          --id https443 \
+          --proto=https \
+          --net=tcp \
+          --addr=0.0.0.0:443
+      when: vulcand is defined


### PR DESCRIPTION
[#99773620 Use vulcand for HTTPS/SSL termination](https://www.pivotaltracker.com/story/show/99773620)
## What

Currently SSL termination is handled by nginx. This story removes nginx from the config and puts the responsibility for SSL termination on vulcand, so we can test the performance of vulcand serving traffic.

This configuration is toggled by setting the variable `vulcand=true` in ansible.
### How this PR should be reviewed

This PR should be reviewed in this context: When provisioning the environment with vulcand enabled (`make <aws|gce> DEPLOY_ENV=... ARGS='-e vulcand=true'`):
1. I want to be able to create a unique [vulcand seal per environment](https://vulcand.io/proxy.html#secret-storage) so I can store certificates in vulcand+etcd.
2. I do not want to setup NGINX as HTTPS proxy of the router, but keep it redirecting from HTTP to HTTPS
3. I want to [setup the certificate in vulcand as described in the vulcand docs](https://vulcand.io/proxy.html#hosts)
4. I want setup vulcand to listen and [serve HTTPS traffic on port 443 by setting up a listener](https://vulcand.io/proxy.html#https-listeners)
### How to test this PR

Start with a new environment (if not, check notes below). Run ansible with vulcand enabled by adding option `-e vulcand=true`, for example: `make <aws|gce> DEPLOY_ENV=... ARGS='-e vulcand=true'`

This would setup the environment running vulcand in the routers. Stuff to check:
1. In routers hosts, vulcand is running and listening in port 443, but nginx only port 80. For that run on the routers `sudo netstat -lptn` and check the output. e.g:
   
   ```
   $ ssh -F ssh.config 10.128.13.130 sudo netstat -lptn
   Active Internet connections (only servers)
   Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
   tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      2435/nginx      
   tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      1032/sshd       
   tcp6       0      0 :::8080                 :::*                    LISTEN      2388/vulcand    
   tcp6       0      0 :::8081                 :::*                    LISTEN      2388/vulcand    
   tcp6       0      0 :::22                   :::*                    LISTEN      1032/sshd       
   tcp6       0      0 :::443                  :::*                    LISTEN      2388/vulcand    
   ```
2. Check that the routers redirect HTTP to HTTPS:
   
   ```
   $ curl -I http://test.dcarley-hipache.tsuru.paas.alphagov.co.uk/
   HTTP/1.1 301 Moved Permanently
   Content-Length: 178
   Content-Type: text/html
   Date: Wed, 05 Aug 2015 12:09:30 GMT
   Location: https://test.dcarley-hipache.tsuru.paas.alphagov.co.uk/
   Server: nginx
   Connection: keep-alive
   ```
3. Check that HTTPS serves our certificate (`Server certificate: *.tsuru.paas.alphagov.co.uk`):

```
$ curl -kv https://test.dcarley-hipache.tsuru.paas.alphagov.co.uk/
* Adding handle: conn: 0x7fadba804000
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x7fadba804000) send_pipe: 1, recv_pipe: 0
* About to connect() to test.dcarley-hipache.tsuru.paas.alphagov.co.uk port 443 (#0)
*   Trying 54.72.105.152...
* Connected to test.dcarley-hipache.tsuru.paas.alphagov.co.uk (54.72.105.152) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
* Server certificate: *.tsuru.paas.alphagov.co.uk
* Server certificate: GlobalSign Domain Validation CA - SHA256 - G2
* Server certificate: GlobalSign Root CA
> GET / HTTP/1.1
> User-Agent: curl/7.30.0
> Host: test.dcarley-hipache.tsuru.paas.alphagov.co.uk
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Content-Type: application/json
< Date: Wed, 05 Aug 2015 12:10:03 GMT
< Content-Length: 21
< 
* Connection #0 to host test.dcarley-hipache.tsuru.paas.alphagov.co.uk left inta

```

Finally, run the smoketests. All tests must pass but the one related to logs (pending fix).

```
make <test-aws|test-gce> DEPLOY_ENV=...
```
### Environment requirements and notes

We assume that you are running from a pristine environment, but if not you can try to solve these issues:
1. Apps might not be registered properly in etcd/vulcand. That causes an error like this when requesting a app: `{"error": "not found"}`. The work around is remove and add the app.
2. To disable NGINX listening on HTTPS, you need to remove the file `/etc/nginx/sites-available/ssl_reverse_proxy.conf` in the routers and restart nginx.
