### PR TITLE
#100407030 Add support for websockets in nginx SSL proxy (2nd attempt)

### DIFF
--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -12,6 +12,9 @@ nginx_sites:
       proxy_redirect http://$hostname/ https://$host/;
       proxy_connect_timeout 15s;
       proxy_buffering off;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
       }
   default:
     - listen 80
@@ -22,3 +25,5 @@ nginx_configs:
     - proxy_set_header X-Real-IP  $remote_addr
     - proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
     - proxy_set_header X-Forwarded-Proto https
+  websocket_map:
+    - map $http_upgrade $connection_upgrade { default Upgrade; '' close; }

--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -16,15 +16,14 @@ nginx_sites:
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
       proxy_set_header Origin http://localhost:{{ upstream_port }};
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP  $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
       }
   default:
     - listen 80
     - return 301 https://$host$request_uri
 nginx_configs:
-  proxy:
-    - proxy_set_header Host $http_host
-    - proxy_set_header X-Real-IP  $remote_addr
-    - proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
-    - proxy_set_header X-Forwarded-Proto https
   websocket_map:
     - map $http_upgrade $connection_upgrade { default Upgrade; '' close; }

--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -15,6 +15,7 @@ nginx_sites:
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
+      proxy_set_header Origin http://localhost:{{ upstream_port }};
       }
   default:
     - listen 80


### PR DESCRIPTION
Refer: [#100407030 vulcand: Log output test fails](https://www.pivotaltracker.com/n/projects/1275640/stories/100407030)
## What

The latest tsuru API server uses [a container per docker node called big-siblings](https://github.com/tsuru/bs#bs) which gather logs and metrics. Logs are stream to Tsuru API server using websockets.

[We setup a nginx proxy to do SSL termination](#74) in front of the API, and currently is not configure to proxy websockets.

In this PR we configure nginx as described [here](http://nginx.org/en/docs/http/websocket.html) to automatically upgrade the HTTP connection when the `Upgrade` header is present (websockets protocol).

**Note**: This PR is a second attempt after #158, which had to be reverted. See below for details.
## How this PR should be reviewed

This PR must be reviewed in this scope:
- I would be able to connect using websockets to a Tsuru API endpoint as `/logs`
- I would be able to keep supporting normal HTTP requests (hipache and vulcand) using nginx as proxy.
## How to test this PR?

The PR is done in the scope of the vulcand stories, but the changes will be enabled for all configurations, not only when `vulcand=true`. 

It does not necessary need the latest version of Tsuru API, but the websockets code is present in the snapshot version so we need to install it by enabling vulcand with `-e vulcand=true`.
### Using `ngrep` to capture the traffic between nginx and the service (api or hipache/vulcand).

You can inspect the traffic between the nginx SSL terminator and the proxied service (api or hipache/vulcand) by:
1. SSH to the server (api or router)
2. Install ngrep: `sudo apt-get install ngrep`
3. Run: `ngrep -W byline -d lo '' tcp port 8080`

This changes should:
- Maintain the original `Host` header from the request. e.p. `Host: dashboard.hector270715-hipache.tsuru2.paas.alphagov.co.uk`
- Set `Connection: close` if `Upgrade` header is not present in the original request
- Set `Connection: Upgrade` if there is a `Upgrade: websocket` header present: ``` 
  - You can simulate this using a websocket client (see below) or doing `curl -H 'Upgrade: websocket' -I -k https://localhost -H 'Host: dashboard.hector270715-hipache.tsuru2.paas.alphagov.co.uk`
### Testing snapshot tsuru version with websockets

> **Note:** Be aware of the notes in #156, which apply here:
> NB: This isn't intended to convert an existing environment from Hipache to
> Vulcand. The ports of the routers will clash and the previously deployed applications won't be properly 
> registered in vulcand. We only intend to create new environments, for testing, with this feature flag.
1. In this branch run the setup of api nodes **with** `vulcand=true` to install the snapshot Tsuru API version:
    `
   make <aws|gce> DEPLOY_ENV=... ARGS='-l *-api* -e vulcand=true'
   `
2. tsuru API and routers should work as usual: login, list apps, etc.  
3. We should be able to connect using websockets to `/logs` using a websocket client (see below). The command will fail with: `{"error":"wslogs: no token"}` but that is OK, the websocket handshake is completed in this point.
#### Connect using Websocket nodejs client `wscat`

``` bash
# Install wscat from nodejs npm. Other clients are also OK
$ npm install wscat
....
# Connect to logs
$ ~/node_modules/wscat/bin/wscat --connect wss://dcarley-api.tsuru.paas.alphagov.co.uk:443/logs
connected (press CTRL+C to quit)
< {"error":"wslogs: no token"}
disconnected
```
### Testing stable tsuru version with hipache
1. In this branch run the setup all the nodes **without** `vulcand=true` to install the stable Tsuru API version:
    `
   make <aws|gce> DEPLOY_ENV=... 
   `
2. tsuru API and routers should work as usual: login, list apps, requests do requests, etc.
### Issues in PR #158

There was an issue in the proxy for the routers. The router (hipache) was losing the `Host` header. 

The reason is described [in the nginx `proxy_set_header` documentation](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header)

> These directives are inherited from the previous level if and only if there are no proxy_set_header directives defined on the current level. By default, only two fields are redefined:
> (edited)

We were defining some default `proxy_set_header` at the `http` context in `/etc/nginx/proxy_params`:

```
proxy_set_header Host $http_host;
proxy_set_header X-Real-IP $remote_addr;
proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
proxy_set_header X-Forwarded-Proto $scheme;
```

Which is lost because we use proxy_set_header in the server context itself for the `Upgrade` header. 

The solution is just move the directives in the `server` context.
