### PR TITLE
[#99119628] wake-gce: wake instances in parallel

### DIFF
--- a/wake-gce.yml
+++ b/wake-gce.yml
@@ -1,15 +1,8 @@
 ---
-
 # Start all the instances in the specified GCE deployment
   - hosts: localhost
     tasks:
-      - name: Deploy gce.py
-        file: src=gce.py dest=./gce.py mode=0744
-      - name: Deploy secrets.py
-        file: src=secrets.py dest=./secrets.py mode=0700
-
       - name: Wake instances
         shell: "./gce.py --start {{ item }} &"
         when: item | match("^{{ deploy_env }}-*")
         with_items: groups['status_terminated']
-

--- a/wake-gce.yml
+++ b/wake-gce.yml
@@ -9,7 +9,7 @@
         file: src=secrets.py dest=./secrets.py mode=0700
 
       - name: Wake instances
-        shell: "./gce.py --start {{ item }}"
+        shell: "./gce.py --start {{ item }} &"
         when: item | match("^{{ deploy_env }}-*")
         with_items: groups['status_terminated']
 


### PR DESCRIPTION
GCE has been recently getting slower and waking all instances one by one is taking unexpectedly long. Worst case scenario is that all requests time out after 180 seconds. There's no need to start instances one by one. Wake them all in parallel. The children of ansible run (gce.py script instances waking your instances up) remain running till they succeed or time out. You can then check manually what's the state of your environment and if appropriate run the wake script again, which will attempt to start all instances in "terminated" state.
