### PR TITLE
[#100410408] makefile: use empty inventory for aws start/stop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,14 +110,14 @@ diff-vault:
 		|| [ $$? -eq 1 ]'
 
 start-aws: check-env-var render-ssh-config
-	ansible-playbook -i "localhost," -c local start-stop-ec2.yml -e deploy_env=${DEPLOY_ENV} -e state=running
+	ansible-playbook -i empty_inventory start-stop-ec2.yml -e deploy_env=${DEPLOY_ENV} -e state=running
 
 start-gce: check-env-var render-ssh-config
 	SSL_CERT_FILE=$(shell python -m certifi) ansible-playbook -i gce.py start-stop-gce.yml \
 	-e deploy_env=${DEPLOY_ENV} -e action=start -e status=terminated
 
 suspend-aws: check-env-var render-ssh-config
-	ansible-playbook -i "localhost," -c local start-stop-ec2.yml -e deploy_env=${DEPLOY_ENV} -e state=stopped
+	ansible-playbook -i empty_inventory start-stop-ec2.yml -e deploy_env=${DEPLOY_ENV} -e state=stopped
 
 suspend-gce: check-env-var render-ssh-config
 	SSL_CERT_FILE=$(shell python -m certifi) ansible-playbook -i gce.py start-stop-gce.yml \


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1275640/stories/100410408

With Ansible, when you specify `-i "localhost,"` inventory, you need to add `-c local` so that the script runs in the current directory (as it expects). However ansible modules themselves run from the temp directory and don't respect your virtual environment. This way start-stop-ec2 playbook fails on ec2 module, not being able to find boto library, which gets installed only in your virtual environment.

Using empty inventory instead of `-i "localhost,"` changes behaviour of ansible a bit. Modules are now correctly able to find the boto library and aws start and suspend operations work correctly.
