### PR TITLE
[#101683958] Push unambiguous reference branch in gandalf

### DIFF
--- a/post-install.yml
+++ b/post-install.yml
@@ -102,7 +102,7 @@
 
     - name: Post Install Tasks | Git push dashboard to gandalf
       shell: >
-        git push {{ dashboard_git_remote.stdout }} HEAD:master
+        git push {{ dashboard_git_remote.stdout }} HEAD:refs/heads/master
       args:
         chdir: /tmp/tsuru-dashboard
 
@@ -131,7 +131,7 @@
 
     - name: Post Install Tasks | Git push postgresapi to gandalf
       shell: >
-        git push {{ postgresapi_git_remote.stdout }} HEAD:master
+        git push {{ postgresapi_git_remote.stdout }} HEAD:refs/heads/master
       args:
         chdir: /tmp/postgresapi
       register: postgresapi_push_result
@@ -216,7 +216,7 @@
 
     - name: Post Install Tasks | Git push elasticsearchapi to gandalf
       shell: >
-        git push {{ elasticsearchapi_git_remote.stdout }} HEAD:master
+        git push {{ elasticsearchapi_git_remote.stdout }} HEAD:refs/heads/master
       args:
         chdir: /tmp/elasticsearchapi
 


### PR DESCRIPTION
From [#101683958 ansible fails deploying posgresapi because it does not specify unambiguous remote branch](https://www.pivotaltracker.com/story/show/101683958)
# What

After #167 in b49b59588fb77a1587113ebb7a39dbeff06645a8, when deploying to the remote repository in gandalf, we might hit this error if the remote master branch does not exist (i.e. it is a new app):

```
# git push git@ci-gandalf.tsuru2.paas.alphagov.co.uk:elasticsearchapi.git HEAD:master
error: unable to push to unqualified destination: master
The destination refspec neither matches an existing ref on the remote nor
begins with refs/, and we are unable to guess a prefix based on the source ref.
error: failed to push some refs to 'git@ci-gandalf.tsuru2.paas.alphagov.co.uk:elasticsearchapi.git'
```

This happens if you are using a detach repository (as we do to be able to use pined versions of code in b49b59588fb77a1587113ebb7a39dbeff06645a8), you specify the remote branch with `HEAD:master`  but it is not in the remote repo. Git does not know what kind of reference is this (tag, branch, etc) and fails.

To ensure that the push works we need to use an unambiguous reference, as `HEAD:refs/heads/master`, [as described here](http://stackoverflow.com/questions/28417845/pushing-a-large-github-repo-fails-with-unable-to-push-to-unqualified-destinatio).
# how to test it

Ansible should be able to deploy apps like postgresapi pointing to a old commit (not latest master) in a brand new environment. You can simulate it by: 
1. Create a new app
2. Get a detached git repo:

```
git clone https://github.com/tsuru/postgres-api
cd postgres-api/
git checkout HEAD~1 # get a detached HEAD
```
1. Try to push to a new app:

```
tsuru app-create test python
git push git@<envname>-gandalf.tsuru2.paas.alphagov.co.uk:test.git HEAD:master
```
# Who can review it

anyone but me, @keymon 
