### PR TITLE
[#107185318] Reconfigure the nginx on Tsuru to allow larger file upload

### DIFF
--- a/ssl_proxy_vars.yml
+++ b/ssl_proxy_vars.yml
@@ -5,6 +5,7 @@ nginx_sites:
     - ssl_certificate wildcard.{{ domain_name }}.site.chain.crt
     - ssl_certificate_key wildcard.{{ domain_name }}.key
     - server_name {{ domain_name }}
+    - client_max_body_size 512m
     - location / {
       proxy_pass http://localhost:{{ upstream_port }}/;
       proxy_redirect default;


### PR DESCRIPTION
Rather than setting this to 0 and allowing uploads of any size I limited it to 512m, as anything larger than this is really getting silly for deployment on a PaaS.
