### PR TITLE
[#107186282] Add nodejs platform

### DIFF
--- a/post-install.yml
+++ b/post-install.yml
@@ -65,6 +65,10 @@
       shell: >
         tsuru-admin platform-add static -d https://raw.github.com/tsuru/basebuilder/master/static/Dockerfile
       when: "not 'static' in tsuru_platforms.stdout"
+    - name: Post Install Tasks | Tsuru platform add nodejs
+      shell: >
+        tsuru-admin platform-add nodejs -d https://raw.github.com/tsuru/basebuilder/master/nodejs/Dockerfile
+      when: "not 'nodejs' in tsuru_platforms.stdout"
 
     - name: Post Install Tasks | Tsuru list tsuru_deployer key
       shell: >


### PR DESCRIPTION
[Add Node.js platform to Tsuru Trial](https://www.pivotaltracker.com/story/show/107186282)
## What

One of the sample apps requires node.js - we should ensure that it is installed on the trial environment.
## How this PR should be reviewed

This PR has been lovingly crafted with the help of some house-elves from the Hogwarts kitchens and is to be reviewed with the following narrative:
- While muttering a minor incantation, I want to:
  - Conjure a new nodejs platform in order to summon nodejs applications onto it
## How to test this PR

Deploy a platform and deploy a nodejs application onto it:

```
wget https://github.com/cloudfoundry-community/etherpad-lite-cf/releases/download/1.5.7-cf/etherpad-lite-cf.zip
mkdir etherpad
cd etherpad
unzip ../etherpad-lite-cf.zip

Deploy Etherpad on Tsuru:

edit bin/installDeps.sh. Remove or comment out this section:

#if [ ! $NODE_V_MINOR = "v0.10" ] && [ ! $NODE_V_MINOR = "v0.11" ] && [ ! $NODE_V_MINOR = "v0.12" ]; then
#  if [ ! $IOJS_VERSION ]; then
#    echo "You're running a wrong version of node, or io.js is not installed. You're using $NODE_VERSION, we need v0.10.x, v0.11.x or v0.12.x" >&2
#    exit 1
#  fi
#fi

edit package.json
Add   "license": "Apache-2.0" afer this section:
  "version": "1.5.7-cf"

bin/installDeps.sh
tsuru app-create etherpad nodejs
tsuru app-deploy .
```
## Who should review and merge this PR
- Any member of House Gryffindor can review this PR, if they all in a Defending Against the Dark Arts lesson then any member of the core team will do with the exception of @actionjack and @jimconner who lovingly crafted this PR for your entertainment and enjoyment
