### PR TITLE
[#107379388] Add persistent volume for redis-mongo

### DIFF
--- a/tsuru_db.yml
+++ b/tsuru_db.yml
@@ -2,7 +2,8 @@
 - hosts: "{{ hosts_prefix }}-tsuru-db"
   sudo: yes
   vars:
-    mongodb_conf_dbpath: "/var/lib/mongodb"
+    mongodb_conf_dbpath: "/opt/data/mongodb"
+    redis_db_dir: "/opt/data/redis"
     etcd_interface: eth0
   pre_tasks:
     - name: Add tsuru DB into etcd group
@@ -13,22 +14,12 @@
     - greendayonfire.mongodb
     - { role: retr0h.etcd, when: vulcand is defined }
 
-#FIXME: Remove when deployed to all environments
   post_tasks:
-    - name: MongoDB | Check /data/db directory
-      stat: path=/data/db
-      register: mongo_data_db
-    - name: MongoDB | Migrate data - stop mongo
-      service: name=mongod state=stopped
-      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
-    - name: MongoDB | Migrate data - prepare destination
-      shell: >
-        rm -rf {{ mongodb_conf_dbpath }}
-      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
-    - name: MongoDB | Migrate data - move data dir
-      shell: >
-        mv /data/db {{ mongodb_conf_dbpath }}
-      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
-    - name: MongoDB | Migrate data - start mongo
-      service: name=mongod state=started
-      when: mongo_data_db.stat.isdir is defined and mongo_data_db.stat.isdir
+    - name: Create /opt/data/redis directory
+      file: path=/opt/data/redis state=directory mode=0755 owner=redis group=redis
+      notify: "restart redis"
+
+  handlers:
+    - name: restart redis
+      service: name=redis state=restarted
+


### PR DESCRIPTION
**What**

We wish to have a persistent disk used for data storage on MongoDB and Redis roles. They both
co-exist on the same tsuru-db host.
This PR changes the data_directory path for Mongo and Redis to /opt/data/<db_name>

**How this PR should be reviewed**

This PR should reviewed in the following context:
- I no longer need 'FIXME' section - it has all been fixed for the last six months.
- I need a mongo and redis installed to an alternate path to make use of a persistent disk attached to my tsuru-db instance

**How to test this PR**
- Deploy tsuru to aws using terraform and ansible as normal.
- Confirm that /opt/data contains a filesystem (lost+found dir present) and that redis and mongo data directories are present on the disk
- Terminate the tsuru-db insance using the EC2 console
- Reprovision the tsuru-db intance using terraform+ansible as normal - it should be recreated with all of the previous data kept intact.
- Destroy the tsuru environment you just created by following the steps in the README.md

**Who should review this PR**
- Anyone in the core team except @timmow who I paired with :-p
