### PR TITLE
[#107718086] add tsuru dashboard

### DIFF
--- a/files/grafana-lib.sh
+++ b/files/grafana-lib.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Used for this script to talk to the Grafana API
+GRAFANA_URL=http://localhost:3000
+COOKIEJAR="/tmp/grafana_session_$$"
+
+function grafana_url {
+  echo -e ${GRAFANA_URL}/api/
+}
+
+function success {
+  echo "$(tput setaf 2)""$*""$(tput sgr0)"
+}
+
+function info {
+  echo "$(tput setaf 3)""$*""$(tput sgr0)"
+}
+
+function error {
+  echo "$(tput setaf 1)""$*""$(tput sgr0)" 1>&2
+  exit 1
+}
+
+function setup_grafana_session {
+  username=${1-admin}; shift
+  password=${1-admin}; shift
+  if ! curl -H 'Content-Type: application/json;charset=UTF-8' \
+    --data-binary "{\"user\":\"$username\",\"email\":\"\",\"password\":\"$password\"}" \
+    --cookie-jar "$COOKIEJAR" \
+    "${GRAFANA_URL}/login" > /dev/null 2>&1 ; then
+    echo
+    error "Grafana Session: Couldn't store cookies at ${COOKIEJAR}"
+  fi
+}
+
+function grafana_has_data_source {
+  setup_grafana_session
+  curl --silent --cookie "$COOKIEJAR" "${GRAFANA_URL}/api/datasources" \
+    | grep "\"name\":\"${1}\"" --silent
+}
+
+function grafana_create_data_source {
+  name=$1; shift
+  type=$1; shift
+  url=$1; shift
+  user=$1; shift
+  password=$1; shift
+  database=$1; shift
+
+  setup_grafana_session
+  curl --cookie "$COOKIEJAR" \
+       -X POST \
+       --silent \
+       -H 'Content-Type: application/json;charset=UTF-8' \
+       --data-binary "{\"name\":\"${name}\",\"type\":\"${type}\",\"url\":\"${url}\",\"access\":\"proxy\",\"database\":\"${database}\",\"user\":\"${user}\",\"password\":\"${password}\"}" \
+       "${GRAFANA_URL}/api/datasources" 2>&1 | grep 'Datasource added' --silent;
+}
+
+function grafana_upload_dashboard {
+  file=$1; shift
+
+  setup_grafana_session
+  curl --cookie "$COOKIEJAR" \
+       -X POST \
+       --silent \
+       -H 'Content-Type: application/json;charset=UTF-8' \
+       -d "{\"overwrite\": true, \"dashboard\": $(sed '0,/RE/s/"id":.*$//'  "$file")}" \
+       "${GRAFANA_URL}/api/dashboards/db" 2>&1
+}

--- a/files/grafana-upload-dashboard.sh
+++ b/files/grafana-upload-dashboard.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. ./grafana-lib.sh
+
+for f in "$@"; do
+  grafana_upload_dashboard "$f"
+done

--- a/files/tsuru-dashboard.json
+++ b/files/tsuru-dashboard.json
@@ -1,0 +1,717 @@
+{
+  "id": 4,
+  "title": "Tsuru dashboard",
+  "originalTitle": "Tsuru dashboard",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "user",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "cpu_usage_user",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"cpu_usage_user\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "A",
+              "tags": []
+            },
+            {
+              "alias": "system",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "cpu_usage_system",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"cpu_usage_system\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "B",
+              "tags": []
+            },
+            {
+              "alias": "load1",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "system_load1",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"system_load1\" WHERE $timeFilter GROUP BY time($interval)",
+              "rawQuery": false,
+              "refId": "C",
+              "tags": []
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "All CPU",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "height": "300"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "used",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "mem_used",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"mem_used\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "A",
+              "tags": []
+            },
+            {
+              "alias": "cached",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "mem_cached",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"mem_cached\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "B",
+              "tags": []
+            },
+            {
+              "alias": "buffered",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "mem_buffered",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"mem_buffered\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "C",
+              "tags": []
+            },
+            {
+              "alias": "free",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "mem_free",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"mem_free\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "D",
+              "tags": []
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "All Memory",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "height": "300"
+        }
+      ],
+      "title": "Row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Read iops",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "io_reads",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"io_reads\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "A",
+              "tags": []
+            },
+            {
+              "alias": "Write iops",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "io_writes",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"io_writes\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "B",
+              "tags": []
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "All Disk IO",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "height": "300"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Used",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "disk_used",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"disk_used\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "A",
+              "tags": []
+            },
+            {
+              "alias": "Free",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "disk_free",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"disk_free\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "B",
+              "tags": []
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "All Disk Space",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "bytes",
+            "none"
+          ],
+          "height": "300"
+        }
+      ],
+      "title": "New row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Used",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "swap_used",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"swap_used\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "A",
+              "tags": []
+            },
+            {
+              "alias": "Free",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "swap_free",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"swap_free\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "B",
+              "tags": []
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Swap",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "height": "300"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Swap in",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "swap_in",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"swap_in\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "A",
+              "tags": []
+            },
+            {
+              "alias": "Swap out",
+              "fields": [
+                {
+                  "func": "mean",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "swap_out",
+              "query": "SELECT mean(\"value\") AS \"value\" FROM \"swap_out\" WHERE $timeFilter GROUP BY time($interval)",
+              "refId": "B",
+              "tags": []
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Swap IO",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "height": "300"
+        }
+      ],
+      "title": "New row"
+    }
+  ],
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "now": true
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "refresh": "30s",
+  "schemaVersion": 7,
+  "version": 9,
+  "links": []
+}

--- a/influx_grafana.yml
+++ b/influx_grafana.yml
@@ -11,6 +11,16 @@
       copy: src=files/datasource.sh dest=/usr/local/bin/datasource.sh mode=0750 owner=root group=root
     - name: Add influx datasource to grafana
       shell: /usr/local/bin/datasource.sh {{ influxdb_database }}
+    - name: Copy grafana API dashboard files
+      copy: src=files/{{ item }} dest=/root/{{ item }} mode=0750 owner=root group=root
+      with_items:
+         - grafana-lib.sh
+         - grafana-upload-dashboard.sh
+         - tsuru-dashboard.json
+    - name: Upload Tsuru dashboard
+      shell: /bin/bash grafana-upload-dashboard.sh tsuru-dashboard.json
+      args:
+        chdir: /root/
 
 - hosts: "{{ hosts_prefix }}-*:!{{ hosts_prefix}}-tsuru-coreos-docker-*"
   sudo: yes


### PR DESCRIPTION
[Create a dashboard that displays metrics for tsuru trial](https://www.pivotaltracker.com/n/projects/1275640/stories/107718086)
## What

Create and automatically upload a dashboard to grafana for displaying useful Tsuru metrics.
## How this PR should be reviewed

In order to automate dashboard deployment:
- we export manually created dashboard as json
- we copy a slightly modified version of @keymon 's [grafana dashboard tools](https://gist.github.com/keymon/64f196f031c2853a06dd) and dashboard.json to the influx-grafana server
- we execute the upload scripts using the ansible post-install task definition
## How to test this PR

Deploy a new platform or apply against existing one. Go to `http://<environment>--grafana.tsuru2.paas.alphagov.co.uk:3000/dashboard/db/tsuru-dashboard` and observe graphs. You can try running smoketests or generate load on the platform otherwise to observe change in the metrics.
## Who should review and merge this PR

Anyone but @mtekel or @actionjack  who worked on this PR.
