### PR TITLE
[#106191568] Bump influxdb role to 0.0.4

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -34,7 +34,7 @@
   version: v0.0.4
 - name: influxdb
   src: https://github.com/alphagov/ansible-playbook-influxdb.git
-  version: v0.0.3
+  version: v0.0.4
 - name: telegraf
   src: https://github.com/alphagov/ansible-playbook-telegraf.git
   version: v0.2.0


### PR DESCRIPTION
# What

Fix in influxdb role to allow automatic restart when the package is upgraded.
# How to review
- Review https://github.com/alphagov/ansible-playbook-influxdb/pull/3 should be sufficient
# Who can review

Anyone but @saliceti or @keymon 
