### PR TITLE
[#107986196] Bump redis role to 0.0.3

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -45,5 +45,5 @@
 # GDS Forked, pull-request sent upstream awaiting merge.
 - name: bennojoy.redis
   src: https://github.com/alphagov/ansible-playbook-redis.git
-  version: v0.0.2
+  version: v0.0.3
 


### PR DESCRIPTION
# What

Bump redis role to 0.0.3 to fix redis restart
# How to review
- Review https://github.com/alphagov/ansible-playbook-redis/pull/4 should be sufficient
- Edit release https://github.com/alphagov/ansible-playbook-redis/releases/tag/v0.0.3 and remove "pre release"
# Who can review

Anyone but @saliceti or @keymon 
